### PR TITLE
Update broken proxy plugin links

### DIFF
--- a/content/plugins/proxy.md
+++ b/content/plugins/proxy.md
@@ -61,7 +61,7 @@ proxy FROM TO... {
   using this **TO** will be ignored. The `grpc` option will talk to a server that has implemented
   the [DnsService](https://github.com/coredns/coredns/pb/dns.proto).
   An out-of-tree plugin that implements the server side of this can be found at
-  [here](https://github.com/infobloxopen/coredns-grpc).
+  [here](https://github.com/johnbelamaric/coredns-grpc).
 
 ## Policies
 
@@ -94,7 +94,7 @@ payload over HTTPS). Note that with `https_google` the entire transport is encry
   * **KEY** **CERT** **CACERT** - Client authentication is used with the specified key/cert pair. The
      server certificate is verified using the **CACERT** file.
   An out-of-tree plugin that implements the server side of this can be found at
-  [here](https://github.com/infobloxopen/coredns-grpc).
+  [here](https://github.com/johnbelamaric/coredns-grpc).
 
 `https_google`
 :    bootstrap **ADDRESS...** is used to (re-)resolve `dns.google.com`.

--- a/content/plugins/proxy.md
+++ b/content/plugins/proxy.md
@@ -59,7 +59,7 @@ proxy FROM TO... {
 * `protocol` specifies what protocol to use to speak to an upstream, `dns` (the default) is plain
   old DNS, and `https_google` uses `https://dns.google.com` and speaks a JSON DNS dialect. Note when
   using this **TO** will be ignored. The `grpc` option will talk to a server that has implemented
-  the [DnsService](https://github.com/coredns/coredns/pb/dns.proto).
+  the [DnsService](https://github.com/coredns/coredns/blob/master/pb/dns.proto).
   An out-of-tree plugin that implements the server side of this can be found at
   [here](https://github.com/johnbelamaric/coredns-grpc).
 


### PR DESCRIPTION
I came across some broken links when following the docs on the website and updated them.

Note: the coredns-grpc plugin is no longer available (or public) under the infobloxopen org, so please let me know if the substitute I put in is the appropriate one.

These links also needs to be replaced in the main coredns repo's readme. I can go ahead and make the same changes there as well, if you give me the green light.