### PR TITLE
Add log plugin in the forwarding Corefile example.

### DIFF
--- a/content/manual/setups.md
+++ b/content/manual/setups.md
@@ -89,6 +89,7 @@ this case, we want *all* queries hitting CoreDNS to be forward to either 8.8.8.8
 ~~~ corefile
 . {
     forward . 8.8.8.8 9.9.9.9
+    log
 }
 ~~~
 Note that *forward* and *proxy* allow you to fine tune the names it will send upstream. Here, we


### PR DESCRIPTION
`log` plugin should be enabled to see query logging.
<!--

Thank you for contributing to CoreDNS' website!

Any pull request that updates a README on https://coredns.io/plugins should be
*redirected* to the CoreDNS repository: https://github.com/coredns/coredns . The READMEs
from that repo are periodically synced to the website.

-->
