### PR TITLE
Add CoreDNS 1.1.3 release notes

### DIFF
--- a/content/blog/coredns-1.1.3.md
+++ b/content/blog/coredns-1.1.3.md
@@ -1,0 +1,57 @@
++++
+title = "CoreDNS-1.1.3 Release"
+description = "CoreDNS-1.1.3 Release Notes."
+tags = ["Release", "1.1.3", "Notes"]
+release = "1.1.3"
+date = "2018-05-24T09:43:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.1.3) of
+CoreDNS-1.1.3!
+
+This release has fixes in the plugins, small core updates and experimental DNS over HTTPs support.
+We also announce the deprecation of a few things in the upcoming release.
+
+# Core
+
+The `-log` flag actually doesn't do anything, so this is a deprecation notice that this flag will be
+removed in the next release.
+
+*Experimental* DNS-over-HTTPS support was added in the server. Use `https://` as the server's scheme
+ in the configuration.
+
+# Plugins
+
+* Deprecation notice for the *reverse* plugin.
+* Deprecation notice for the `https_google` protocol in *proxy*.
+* [*metrics*](/plugin/metrics) All in-tree plugins serve metrics with a `server` label.
+   * *cache* and *dnssec* drop the capacity metrics
+   * add a panic counter: `coredns_panic_count_total`
+* [*etcd*](/plugins/etcd) supports A and AAAA record under the zone's apex.
+* [*rewrite*](/plugins/rewrite) now handles `continue` in response rewrites.
+* [*forward*](/plugin/forward) clean ups, esp when shutting it down.
+* [*cache*](/plugin/cache) adds some optimization.
+* [*kubernetes*](/plugin/kubernetes) adds option to `ignore` services without ready endpoints.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Ahmet Alp Balkan,
+Anton Antonov,
+Cem Türker,
+Chris O'Haver,
+darkweaver87,
+Eugen Kleiner,
+Francois Tur,
+John Belamaric,
+Mario Kleinsasser,
+Miek Gieben,
+Ruslan Drozhdzh,
+Silver,
+Tobias Schmidt,
+Yong Tang.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/content/blog/coredns-1.1.3.md
+++ b/content/blog/coredns-1.1.3.md
@@ -11,7 +11,7 @@ We are pleased to announce the [release](https://github.com/coredns/coredns/rele
 CoreDNS-1.1.3!
 
 This release has fixes in the plugins, small core updates and experimental DNS over HTTPs support.
-We also announce the deprecation of a few things in the upcoming release.
+We also announce the deprecation of a few things.
 
 # Core
 

--- a/content/blog/coredns-1.1.3.md
+++ b/content/blog/coredns-1.1.3.md
@@ -15,16 +15,14 @@ We also announce the deprecation of a few things.
 
 # Core
 
-The `-log` flag actually doesn't do anything, so this is a deprecation notice that this flag will be
-removed in the next release.
-
 *Experimental* DNS-over-HTTPS support was added in the server. Use `https://` as the server's scheme
  in the configuration.
 
+The `-log` flag actually doesn't do anything, so this is a deprecation notice that this flag will be
+removed in the next release.
+
 # Plugins
 
-* Deprecation notice for the *reverse* plugin.
-* Deprecation notice for the `https_google` protocol in *proxy*.
 * [*metrics*](/plugin/metrics) All in-tree plugins serve metrics with a `server` label.
    * *cache* and *dnssec* drop the capacity metrics
    * add a panic counter: `coredns_panic_count_total`
@@ -33,6 +31,8 @@ removed in the next release.
 * [*forward*](/plugin/forward) clean ups, esp when shutting it down.
 * [*cache*](/plugin/cache) adds some optimization.
 * [*kubernetes*](/plugin/kubernetes) adds option to `ignore` services without ready endpoints.
+* Deprecation notice for the *reverse* plugin.
+* Deprecation notice for the `https_google` protocol in *proxy*.
 
 ## Contributors
 

--- a/content/plugins/auto.md
+++ b/content/plugins/auto.md
@@ -4,7 +4,7 @@ description = "*auto* enables serving zone data from an RFC 1035-style master fi
 weight = 1
 tags = [ "plugin", "auto" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.851356"
+date = "2018-05-24T08:47:52.442416"
 +++
 
 ## Description

--- a/content/plugins/autopath.md
+++ b/content/plugins/autopath.md
@@ -4,7 +4,7 @@ description = "*autopath* allows for server-side search path completion."
 weight = 2
 tags = [ "plugin", "autopath" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.851832"
+date = "2018-05-24T08:47:52.442833"
 +++
 
 ## Description
@@ -32,7 +32,9 @@ If a plugin implements the `AutoPather` interface then it can be used.
 
 If monitoring is enabled (via the *prometheus* directive) then the following metric is exported:
 
-* `coredns_autopath_success_count_total{}` - counter of successfully autopath-ed queries.
+* `coredns_autopath_success_count_total{server}` - counter of successfully autopath-ed queries.
+
+The `server` label is explained in the *metrics* plugin documentation.
 
 ## Examples
 

--- a/content/plugins/bind.md
+++ b/content/plugins/bind.md
@@ -4,7 +4,7 @@ description = "*bind* overrides the host to which the server should bind."
 weight = 3
 tags = [ "plugin", "bind" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.852727"
+date = "2018-05-24T08:47:52.443129"
 +++
 
 ## Description

--- a/content/plugins/cache.md
+++ b/content/plugins/cache.md
@@ -4,7 +4,7 @@ description = "*cache* enables a frontend cache."
 weight = 4
 tags = [ "plugin", "cache" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.852969"
+date = "2018-05-24T08:47:52.443392"
 +++
 
 ## Description
@@ -65,13 +65,13 @@ Eviction is done per shard - i.e. when a shard reaches capacity, items are evict
 
 If monitoring is enabled (via the *prometheus* directive) then the following metrics are exported:
 
-* `coredns_cache_size{type}` - Total elements in the cache by cache type.
-* `coredns_cache_capacity{type}` - Total capacity of the cache by cache type.
-* `coredns_cache_hits_total{type}` - Counter of cache hits by cache type.
-* `coredns_cache_misses_total{}` - Counter of cache misses.
-* `coredns_cache_drops_total{}` - Counter of dropped messages.
+* `coredns_cache_size{server, type}` - Total elements in the cache by cache type.
+* `coredns_cache_hits_total{server, type}` - Counter of cache hits by cache type.
+* `coredns_cache_misses_total{server}` - Counter of cache misses.
+* `coredns_cache_drops_total{server}` - Counter of dropped messages.
 
-Cache types are either "denial" or "success".
+Cache types are either "denial" or "success". `Server` is the server handling the request, see the
+metrics plugin for documentation.
 
 ## Examples
 

--- a/content/plugins/chaos.md
+++ b/content/plugins/chaos.md
@@ -4,7 +4,7 @@ description = "*chaos* allows for responding to TXT queries in the CH class."
 weight = 5
 tags = [ "plugin", "chaos" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.853123"
+date = "2018-05-24T08:47:52.443658"
 +++
 
 ## Description

--- a/content/plugins/debug.md
+++ b/content/plugins/debug.md
@@ -4,7 +4,7 @@ description = "*debug* disables the automatic recovery upon a crash so that you'
 weight = 6
 tags = [ "plugin", "debug" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.853246"
+date = "2018-05-24T08:47:52.443851"
 +++
 
 ## Description

--- a/content/plugins/dnssec.md
+++ b/content/plugins/dnssec.md
@@ -4,7 +4,7 @@ description = "*dnssec* enable on-the-fly DNSSEC signing of served data."
 weight = 7
 tags = [ "plugin", "dnssec" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.853432"
+date = "2018-05-24T08:47:52.444092"
 +++
 
 ## Description
@@ -51,10 +51,11 @@ used (See [bugs](#bugs)).
 
 If monitoring is enabled (via the *prometheus* directive) then the following metrics are exported:
 
-* `coredns_dnssec_cache_size{type}` - total elements in the cache, type is "signature".
-* `coredns_dnssec_cache_capacity{type}` - total capacity of the cache, type is "signature".
-* `coredns_dnssec_cache_hits_total{}` - Counter of cache hits.
-* `coredns_dnssec_cache_misses_total{}` - Counter of cache misses.
+* `coredns_dnssec_cache_size{server, type}` - total elements in the cache, type is "signature".
+* `coredns_dnssec_cache_hits_total{server}` - Counter of cache hits.
+* `coredns_dnssec_cache_misses_total{server}` - Counter of cache misses.
+
+The label `server` indicated the server handling the request, see the *metrics* plugin for details.
 
 ## Examples
 

--- a/content/plugins/dnstap.md
+++ b/content/plugins/dnstap.md
@@ -4,7 +4,7 @@ description = "*dnstap* enable logging to dnstap"
 weight = 8
 tags = [ "plugin", "dnstap" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.853597"
+date = "2018-05-24T08:47:52.444315"
 +++
 
 ## Description

--- a/content/plugins/erratic.md
+++ b/content/plugins/erratic.md
@@ -4,7 +4,7 @@ description = "*erratic* a plugin useful for testing client behavior."
 weight = 9
 tags = [ "plugin", "erratic" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.853752"
+date = "2018-05-24T08:47:52.444539"
 +++
 
 ## Description

--- a/content/plugins/errors.md
+++ b/content/plugins/errors.md
@@ -4,7 +4,7 @@ description = "*errors* enable error logging."
 weight = 10
 tags = [ "plugin", "errors" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.853868"
+date = "2018-05-24T08:47:52.444723"
 +++
 
 ## Description

--- a/content/plugins/etcd.md
+++ b/content/plugins/etcd.md
@@ -4,7 +4,7 @@ description = "*etcd* enables reading zone data from an etcd instance."
 weight = 11
 tags = [ "plugin", "etcd" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.854073"
+date = "2018-05-24T08:47:52.445007"
 +++
 
 ## Description
@@ -129,6 +129,48 @@ Querying with dig:
 ~~~ sh
 % dig @localhost -x 10.0.0.127 +short
 reverse.skydns.local.
+~~~
+
+### Zone name as A record
+
+The zone name itself can be used A record. This behavior can be achieved by writing special entries to the ETCD path of your zone. If your zone is named `skydns.local` for example, you can create an `A` record for this zone as follows:
+
+~~~
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex -d value='{"host":"1.1.1.1","ttl":"60"}'
+~~~
+
+If you query the zone name itself, you will receive the created `A` record:
+
+~~~ sh
+% dig +short skydns.local @localhost
+1.1.1.1
+~~~
+
+If you would like to use DNS RR for the zone name, you can set the following:
+~~~
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex/x1 -d value='{"host":"1.1.1.1","ttl":"60"}'
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex/x2 -d value='{"host":"1.1.1.2","ttl":"60"}'
+~~~
+
+If you query the zone name now, you will get the following response:
+
+~~~ sh
+dig +short skydns.local @localhost
+1.1.1.1
+1.1.1.2
+~~~
+
+If you would like to use `AAAA` records for the zone name too, you can set the following:
+~~~
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex/x3 -d value='{"host":"2003::8:1","ttl":"60"}'
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex/x4 -d value='{"host":"2003::8:2","ttl":"60"}'
+~~~
+
+If you query the zone name now for `AAAA` now, you will get the following response:
+~~~ sh
+dig +short skydns.local AAAA @localhost
+2003::8:1
+2003::8:2
 ~~~
 
 ## Bugs

--- a/content/plugins/federation.md
+++ b/content/plugins/federation.md
@@ -4,7 +4,7 @@ description = "*federation* enables federated queries to be resolved via the kub
 weight = 12
 tags = [ "plugin", "federation" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.854218"
+date = "2018-05-24T08:47:52.445261"
 +++
 
 ## Description

--- a/content/plugins/file.md
+++ b/content/plugins/file.md
@@ -4,7 +4,7 @@ description = "*file* enables serving zone data from an RFC 1035-style master fi
 weight = 13
 tags = [ "plugin", "file" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.854358"
+date = "2018-05-24T08:47:52.445474"
 +++
 
 ## Description

--- a/content/plugins/forward.md
+++ b/content/plugins/forward.md
@@ -4,7 +4,7 @@ description = "*forward* facilitates proxying DNS messages to upstream resolvers
 weight = 14
 tags = [ "plugin", "forward" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.854572"
+date = "2018-05-24T08:47:52.445723"
 +++
 
 ## Description
@@ -23,6 +23,10 @@ When *all* upstreams are down it assumes health checking as a mechanism has fail
 connect to a random upstream (which may or may not work).
 
 This plugin can only be used once per Server Block.
+
+How does *forward* relate to *proxy*? This plugin is the "new" version of *proxy* and is faster
+because it re-uses connections to the upstreams. It also does in-band health checks - using DNS
+instead of HTTP. Since it is newer it has a little less (production) mileage on it.
 
 ## Syntax
 
@@ -99,7 +103,7 @@ IPv6).
 
 ## Examples
 
-Proxy all requests within example.org. to a nameserver running on a different port:
+Proxy all requests within `example.org.` to a nameserver running on a different port:
 
 ~~~ corefile
 example.org {
@@ -152,7 +156,7 @@ service with health checks.
 
 ## Bugs
 
-The TLS config is global for the whole forwarding proxy if you need a different `tls_serveraame` for
+The TLS config is global for the whole forwarding proxy if you need a different `tls_servername` for
 different upstreams you're out of luck.
 
 ## Also See

--- a/content/plugins/health.md
+++ b/content/plugins/health.md
@@ -4,7 +4,7 @@ description = "*health* enables a health check endpoint."
 weight = 15
 tags = [ "plugin", "health" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.854735"
+date = "2018-05-24T08:47:52.445949"
 +++
 
 ## Description
@@ -51,6 +51,17 @@ net {
 }
 ~~~
 
+Note that if you format this in one server block you will get an error on startup, that the second
+server can't setup the health plugin (on the same port).
+
+~~~ txt
+com net {
+    whoami
+    erratic
+    health :8080
+}
+~~~~
+
 ## Plugins
 
 Any plugin that implements the Healther interface will be used to report health.
@@ -85,3 +96,10 @@ Set a lameduck duration of 1 second:
     }
 }
 ~~~
+
+## Bugs
+
+When reloading, the Health handler is stopped before the new server instance is started. 
+If that new server fails to start, then the initial server instance is still available and DNS queries still served, 
+but Health handler stays down. 
+Health will not reply HTTP request until a successful reload or a complete restart of CoreDNS.

--- a/content/plugins/hosts.md
+++ b/content/plugins/hosts.md
@@ -4,7 +4,7 @@ description = "*hosts* enables serving zone data from a `/etc/hosts` style file.
 weight = 16
 tags = [ "plugin", "hosts" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.855718"
+date = "2018-05-24T08:47:52.446188"
 +++
 
 ## Description

--- a/content/plugins/kubernetes.md
+++ b/content/plugins/kubernetes.md
@@ -4,7 +4,7 @@ description = "*kubernetes* enables the reading zone data from a Kubernetes clus
 weight = 17
 tags = [ "plugin", "kubernetes" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.856141"
+date = "2018-05-24T08:47:52.446513"
 +++
 
 ## Description
@@ -43,6 +43,7 @@ kubernetes [ZONES...] {
     endpoint_pod_names
     upstream [ADDRESS...]
     ttl TTL
+    transfer to ADDRESS...
     fallthrough [ZONES...]
 }
 ```
@@ -93,12 +94,19 @@ kubernetes [ZONES...] {
   5 seconds, the maximum is capped at 3600 seconds.
 * `noendpoints` will turn off the serving of endpoint records by disabling the watch on endpoints.
   All endpoint queries and headless service queries will result in an NXDOMAIN.
+* `transfer` enables zone transfers. It may be specified multiples times. `To` signals the direction
+  (only `to` is alllow). **ADDRESS** must be denoted in CIDR notation (127.0.0.1/32 etc.) or just as
+  plain addresses. The special wildcard `*` means: the entire internet.
+  Sending DNS notifies is not supported.
 * `fallthrough` **[ZONES...]** If a query for a record in the zones for which the plugin is authoritative
   results in NXDOMAIN, normally that is what the response will be. However, if you specify this option,
   the query will instead be passed on down the plugin chain, which can include another plugin to handle
   the query. If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin
   is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only
   queries for those zones will be subject to fallthrough.
+* `ignore empty_service` return NXDOMAIN for services without any ready endpoint addresses (e.g. ready pods). 
+  This allows the querying pod to continue searching for the service in the search path. 
+  The search path could, for example, include another kubernetes cluster.
 
 ## Health
 
@@ -202,7 +210,7 @@ or the word "any"), then that label will match all values.  The labels that acce
  * _port and/or protocol_ in an `SRV` request: __port_.__protocol_.service.namespace.svc.zone.,
    e.g. `_http.*.service.ns.svc.cluster.local`
  * multiple wild cards are allowed in a single query, e.g. `A` Request `*.*.svc.zone.` or `SRV` request `*.*.*.*.svc.zone.`
- 
+
  For example, Wildcards can be used to resolve all Endpoints for a Service as `A` records. e.g.: `*.service.ns.svc.myzone.local` will return the Endpoint IPs in the Service `service` in namespace `default`:
  ```
 *.service.default.svc.cluster.local. 5	IN A	192.168.10.10

--- a/content/plugins/loadbalance.md
+++ b/content/plugins/loadbalance.md
@@ -4,7 +4,7 @@ description = "*loadbalance* acts as a round-robin DNS loadbalancer by randomizi
 weight = 18
 tags = [ "plugin", "loadbalance" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.856987"
+date = "2018-05-24T08:47:52.446777"
 +++
  in the answer.
 

--- a/content/plugins/log.md
+++ b/content/plugins/log.md
@@ -4,7 +4,7 @@ description = "*log* enables query logging to standard output."
 weight = 19
 tags = [ "plugin", "log" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.857360"
+date = "2018-05-24T08:47:52.447045"
 +++
 
 ## Description

--- a/content/plugins/metrics.md
+++ b/content/plugins/metrics.md
@@ -4,7 +4,7 @@ description = "*prometheus* enables [Prometheus](https://prometheus.io/) metrics
 weight = 20
 tags = [ "plugin", "metrics" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.857825"
+date = "2018-05-24T08:47:52.447286"
 +++
 
 ## Description
@@ -14,6 +14,7 @@ The default location for the metrics is `localhost:9153`. The metrics path is fi
 The following metrics are exported:
 
 * `coredns_build_info{version, revision, goversion}` - info about CoreDNS itself.
+* `coredns_panic_count_total{}` - total number of panics.
 * `coredns_dns_request_count_total{server, zone, proto, family}` - total query count.
 * `coredns_dns_request_duration_seconds{server, zone}` - duration to process each query.
 * `coredns_dns_request_size_bytes{server, zone, proto}` - size of the request in bytes.
@@ -73,5 +74,7 @@ then:
 
 ## Bugs
 
-When reloading, we keep the handler running, meaning that any changes to the handler's address
-aren't picked up. You'll need to restart CoreDNS for that to happen.
+When reloading, the Prometheus handler is stopped before the new server instance is started. 
+If that new server fails to start, then the initial server instance is still available and DNS queries still served, 
+but Prometheus handler stays down. 
+Prometheus will not reply HTTP request until a successful reload or a complete restart of CoreDNS.

--- a/content/plugins/nsid.md
+++ b/content/plugins/nsid.md
@@ -4,7 +4,7 @@ description = "*nsid* adds an identifier of this server to each reply."
 weight = 21
 tags = [ "plugin", "nsid" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.858263"
+date = "2018-05-24T08:47:52.447546"
 +++
 
 ## Description

--- a/content/plugins/pprof.md
+++ b/content/plugins/pprof.md
@@ -4,7 +4,7 @@ description = "*pprof* publishes runtime profiling data at endpoints under `/deb
 weight = 22
 tags = [ "plugin", "pprof" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.858477"
+date = "2018-05-24T08:47:52.447810"
 +++
 
 ## Description
@@ -12,12 +12,8 @@ date = "2018-04-23T13:05:33.858477"
 You can visit `/debug/pprof` on your site for an index of the available endpoints. By default it
 will listen on localhost:6053.
 
-> This is a debugging tool. Certain requests (such as collecting execution traces) can be slow. If
-> you use pprof on a live server, consider restricting access or enabling it only temporarily.
-
-For more information, please see [Go's pprof
-documentation](https://golang.org/pkg/net/http/pprof/) and read
-[Profiling Go Programs](https://blog.golang.org/profiling-go-programs).
+This is a debugging tool. Certain requests (such as collecting execution traces) can be slow. If
+you use pprof on a live server, consider restricting access or enabling it only temporarily.
 
 This plugin can only be used once per Server Block.
 
@@ -38,6 +34,8 @@ Enable pprof endpoints:
     pprof
 }
 ~~~
+
+And use the pprof tool to get statistics: `go tool pprof http://localhost:6053`.
 
 Listen on an alternate address:
 

--- a/content/plugins/proxy.md
+++ b/content/plugins/proxy.md
@@ -4,7 +4,7 @@ description = "*proxy* facilitates both a basic reverse proxy and a robust load 
 weight = 23
 tags = [ "plugin", "proxy" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.858737"
+date = "2018-05-24T08:47:52.448106"
 +++
 
 ## Description
@@ -168,7 +168,7 @@ Proxy everything except `example.org` using the host's `resolv.conf`'s nameserve
 ~~~ corefile
 . {
     proxy . /etc/resolv.conf {
-        except miek.nl example.org
+        except example.org
     }
 }
 ~~~

--- a/content/plugins/reload.md
+++ b/content/plugins/reload.md
@@ -4,10 +4,13 @@ description = "*reload* allows automatic reload of a changed Corefile"
 weight = 24
 tags = [ "plugin", "reload" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.858989"
+date = "2018-05-24T08:47:52.448362"
 +++
 
 ## Description
+
+This plugin allows automatic reload of a changed _Corefile_.
+To enable automatic reloading of _zone file_ changes, use the `auto` plugin.
 
 This plugin periodically checks if the Corefile has changed by reading
 it and calculating its MD5 checksum. If the file has changed, it reloads

--- a/content/plugins/reverse.md
+++ b/content/plugins/reverse.md
@@ -4,7 +4,7 @@ description = "*reverse* allows for dynamic responses to PTR and the related A/A
 weight = 25
 tags = [ "plugin", "reverse" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.859198"
+date = "2018-05-24T08:47:52.448648"
 +++
 
 ## Description

--- a/content/plugins/root.md
+++ b/content/plugins/root.md
@@ -4,7 +4,7 @@ description = "*root* simply specifies the root of where to find (zone) files."
 weight = 27
 tags = [ "plugin", "root" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.859704"
+date = "2018-05-24T08:47:52.449187"
 +++
 
 ## Description

--- a/content/plugins/route53.md
+++ b/content/plugins/route53.md
@@ -4,7 +4,7 @@ description = "*route53* enables serving zone data from AWS route53."
 weight = 28
 tags = [ "plugin", "route53" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.859903"
+date = "2018-05-24T08:47:52.449410"
 +++
 
 ## Description

--- a/content/plugins/secondary.md
+++ b/content/plugins/secondary.md
@@ -4,7 +4,7 @@ description = "*secondary* enables serving a zone retrieved from a primary serve
 weight = 29
 tags = [ "plugin", "secondary" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.860083"
+date = "2018-05-24T08:47:52.449662"
 +++
 
 ## Description

--- a/content/plugins/template.md
+++ b/content/plugins/template.md
@@ -4,7 +4,7 @@ description = "*template* allows for dynamic responses based on the incoming que
 weight = 30
 tags = [ "plugin", "template" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.860403"
+date = "2018-05-24T08:47:52.450010"
 +++
 
 ## Description
@@ -67,11 +67,12 @@ The output of the template must be a [RFC 1035](https://tools.ietf.org/html/rfc1
 
 If monitoring is enabled (via the *prometheus* directive) then the following metrics are exported:
 
-* `coredns_template_matches_total{regex}` the total number of matched requests by regex.
-* `coredns_template_template_failures_total{regex,section,template}` the number of times the Go templating failed. Regex, section and template label values can be used to map the error back to the config file.
-* `coredns_template_rr_failures_total{regex,section,template}` the number of times the templated resource record was invalid and could not be parsed. Regex, section and template label values can be used to map the error back to the config file.
+* `coredns_template_matches_total{server, regex}` the total number of matched requests by regex.
+* `coredns_template_template_failures_total{server, regex,section,template}` the number of times the Go templating failed. Regex, section and template label values can be used to map the error back to the config file.
+* `coredns_template_rr_failures_total{server, regex,section,template}` the number of times the templated resource record was invalid and could not be parsed. Regex, section and template label values can be used to map the error back to the config file.
 
-Both failure cases indicate a problem with the template configuration.
+Both failure cases indicate a problem with the template configuration. The `server` label indicates
+the server incrementing the metric, see the *metrics* plugin for details.
 
 ## Examples
 

--- a/content/plugins/tls.md
+++ b/content/plugins/tls.md
@@ -4,7 +4,7 @@ description = "*tls* allows you to configure the server certificates for the TLS
 weight = 31
 tags = [ "plugin", "tls" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.860732"
+date = "2018-05-24T08:47:52.450277"
 +++
 
 ## Description
@@ -25,8 +25,10 @@ wire data of a DNS message.
 ## Syntax
 
 ~~~ txt
-tls CERT KEY CA
+tls CERT KEY [CA]
 ~~~
+
+Parameter CA is optional. If not set, system CAs can be used to verify the client certificate
 
 ## Examples
 

--- a/content/plugins/trace.md
+++ b/content/plugins/trace.md
@@ -4,7 +4,7 @@ description = "*trace* enables OpenTracing-based tracing of DNS requests as they
 weight = 32
 tags = [ "plugin", "trace" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.860959"
+date = "2018-05-24T08:47:52.450556"
 +++
 
 ## Description

--- a/content/plugins/whoami.md
+++ b/content/plugins/whoami.md
@@ -4,7 +4,7 @@ description = "*whoami* returns your resolver's local IP address, port and trans
 weight = 33
 tags = [ "plugin", "whoami" ]
 categories = [ "plugin" ]
-date = "2018-04-23T13:05:33.861159"
+date = "2018-05-24T08:47:52.450894"
 +++
 
 ## Description
@@ -52,3 +52,10 @@ When queried for "example.org A", CoreDNS will respond with:
 example.org.            0       IN      A       10.240.0.1
 _udp.example.org.       0       IN      SRV     0 0 40212
 ~~~
+
+## See Also
+
+[Read the blog post][blog] on how this plugin is built, or [explore the source code][code].
+
+[blog]: https://coredns.io/2017/03/01/how-to-add-plugins-to-coredns/
+[code]: https://github.com/coredns/coredns/blob/master/plugin/whoami/

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.1.2"
+  version = "1.1.3"


### PR DESCRIPTION
Create blog post and sync all READMEs from 1.1.3 into the repo.

<!--

Thank you for contributing to CoreDNS' website!

Any pull request that updates a README on https://coredns.io/plugins should be
*redirected* to the CoreDNS repository: https://github.com/coredns/coredns . The READMEs
from that repo are periodically synced to the website.

-->
