### PR TITLE
- add a link to survey for coredns adoption by kubernetes users

### DIFF
--- a/themes/coredns/layouts/index.html
+++ b/themes/coredns/layouts/index.html
@@ -26,9 +26,11 @@
      <div class="text-center">
         <p class="outline big">
         In <a href="https://kubernetes.io">Kubernetes</a> 1.11, CoreDNS is <a
-            href="https://kubernetes.io/blog/2018/07/10/coredns-ga-for-kubernetes-cluster-dns/">the default</a> DNS server.
+                href="https://kubernetes.io/blog/2018/07/10/coredns-ga-for-kubernetes-cluster-dns/">the default</a> DNS server.<br>
+            <b>Already adopted CoreDNS in your cluster ? <a href="https://www.surveymonkey.com/r/SKZQSLK">provide us your feedback</a></b>
         </p>
      </div>
+    <br>
 
      <div class="text-center">
         <p class="outline big">


### PR DESCRIPTION
<!--

Thank you for contributing to CoreDNS' website!

Any pull request that updates a README on https://coredns.io/plugins should be
*redirected* to the CoreDNS repository: https://github.com/coredns/coredns . The READMEs
from that repo are periodically synced to the website.

-->


Add a short sentence on home page coredns.io to invite CoreDNS adopters to fill the survey.
NOTE: I tested locally with Hugo.
