### PR TITLE
Correct main page: Not default in k8s yet

### DIFF
--- a/themes/coredns/layouts/index.html
+++ b/themes/coredns/layouts/index.html
@@ -26,7 +26,7 @@
      <div class="text-center">
         <p class="outline big">
         In <a href="https://kubernetes.io">Kubernetes</a> 1.11, CoreDNS is <a
-            href="https://kubernetes.io/blog/2018/07/10/coredns-ga-for-kubernetes-cluster-dns/">the default</a> DNS server.
+            href="https://kubernetes.io/blog/2018/07/10/coredns-ga-for-kubernetes-cluster-dns/">an approved</a> cluster DNS server.
         </p>
      </div>
 


### PR DESCRIPTION
We are not default in k8s quite yet.  We graduated from beta in 1.11.  Essentially, in 1.11, CoreDNS is an approved alternative to kube-dns.

We are default in the "kubeadm" installer, but strictly not yet "the default in kubernetes".

The goal is to be default in the future.  The graduation criteria for this (set by the k8s team) is to pass a to-be-defined threshold of large scale production adoptions (hence the recent survey).

Unlikely to be 1.12, possibly 1.13.