### PR TITLE
Adjust example to use foo.example.com

### DIFF
--- a/content/blog/custom-dns-and-kubernetes.md
+++ b/content/blog/custom-dns-and-kubernetes.md
@@ -71,7 +71,7 @@ If you don't see a command prompt, try pressing enter.
 / # host foo
 foo.default.svc.cluster.local has address 10.0.0.72
 / # host foo.example.com
-foo.default.svc.cluster.local has address 10.0.0.72
+foo.example.com has address 10.0.0.72
 / # host bar.example.com
 Host bar.example.com not found: 3(NXDOMAIN)
 / #
@@ -144,7 +144,7 @@ If you don't see a command prompt, try pressing enter.
 / # host foo
 foo.default.svc.cluster.local has address 10.0.0.72
 / # host foo.example.com
-foo.default.svc.cluster.local has address 10.0.0.72
+foo.example.com has address 10.0.0.72
 / # host example.org
 example.org has address 127.0.0.1
 / #


### PR DESCRIPTION
Adjust example in content/blog/custom-dns-and-kubernetes.md to use foo.example.com instead of foo.default.svc.cluster.local. Like in the comment
<!--

Thank you for contributing to CoreDNS' website!

Any pull request that updates a README on https://coredns.io/plugins should be
*redirected* to the CoreDNS repository: https://github.com/coredns/coredns . The READMEs
from that repo are periodically synced to the website.

-->
