### PR TITLE
A small typo fix

### DIFF
--- a/content/plugins/forward.md
+++ b/content/plugins/forward.md
@@ -170,7 +170,7 @@ Or with multiple upstreams from the same provider
 ~~~ corefile
 . {
     forward . tls://1.1.1.1 tls://1.0.0.1 {
-       tls_servername loudflare-dns.com
+       tls_servername cloudflare-dns.com
        health_check 5s
     }
     cache 30


### PR DESCRIPTION
Cloudflare TLS server name is cloudflare-dns.com

<!--

Thank you for contributing to CoreDNS' website!

Any pull request that updates a README on https://coredns.io/plugins should be
*redirected* to the CoreDNS repository: https://github.com/coredns/coredns . The READMEs
from that repo are periodically synced to the website.

-->
