### PR TITLE
Add additional deprecation notice

### DIFF
--- a/content/blog/coredns-1.4.0.md
+++ b/content/blog/coredns-1.4.0.md
@@ -13,9 +13,8 @@ of CoreDNS-1.4.0! Our first release after we became a graduated project in
 
 Deprecation notice for the *next* release:
 
- *  [*auto*](/plugins/auto) will deprecate **TIMEOUT** and `no_reload` and defaults the use of
-    `reload`. This makes [*file*](/plugins/file) and [*auto*](/plugins/auto) to use the same syntax
-    for reload intervals.
+ *  [*auto*](/plugins/auto) will deprecate **TIMEOUT** and recommends the use of RELOAD ([2516](https://github.com/coredns/coredns/issues/2516).
+ *  [*auto*](/plugins/file) and [*file*](/plugins/auto) will deprecate NO_RELOAD and recommends the use of RELOAD set to 0 ([2536](https://github.com/coredns/coredns/issues/2536).
  *  [*health*](/plugins/health) will revert back to report process level health without plugin
     status. A new *ready* plugin will make sure plugins have at least completed their startup
     sequence.


### PR DESCRIPTION
Docs are already in and a warning for the code can be done in a minor release.

<!--

Thank you for contributing to CoreDNS' website!

Any pull request that updates a README on https://coredns.io/plugins should be
*redirected* to the CoreDNS repository: https://github.com/coredns/coredns . The READMEs
from that repo are periodically synced to the website.

-->
