### PR TITLE
fix(blog): Fix link to previous release notes.

### DIFF
--- a/content/blog/coredns-1.4.0.md
+++ b/content/blog/coredns-1.4.0.md
@@ -21,7 +21,7 @@ Deprecation notice for the *next* release:
  *  The [*proxy*](/plugins/proxy) will be moved to an external repository and as such be deprecated
     from the default set of plugin; use the [*forward*](/plugins/forward) as a replacement.
 
-The [previous](/019/01/13/coredns-1.3.1-release/) announced deprecations have been enacted.
+The [previous](/2019/01/13/coredns-1.3.1-release/) announced deprecations have been enacted.
 
 The (unused) gRPC watch functionally was removed from the server.
 


### PR DESCRIPTION
### What does this PR do?
Congrats on the `1.4.0` release!

I was checking out the release notes and found this broken link. Easy-peasy fix. Peep it @ https://corednsio-aokztoobta.now.sh/2019/03/03/coredns-1.4.0-release/ to verify.