### PR TITLE
make:installation: remove inexistent target

### DIFF
--- a/content/manual/installation.md
+++ b/content/manual/installation.md
@@ -60,7 +60,7 @@ $ mkdir -p $GOPATH/src/github.com/coredns
 $ cd $GOPATH/src/github.com/coredns/
 $ git clone git@github.com:coredns/coredns
 $ cd coredns
-$ make CHECKS= godeps all
+$ make CHECKS= all
 ~~~
 
 ## Testing


### PR DESCRIPTION
Hello.
Coredns is using go module and there is not target named godeps in Makefile. So remove it