### PR TITLE
blog: Corefile.md fix link to whoami plugin page

### DIFF
--- a/content/blog/corefile.md
+++ b/content/blog/corefile.md
@@ -39,7 +39,7 @@ a CH class query: `dig CH txt version.bind @localhost`
 ~~~
 
 If CoreDNS can't find a `Corefile` to load is loads the following builtin one that loads the
-[*whoami* plugin](/plugin/whoami):
+[*whoami* plugin](/plugins/whoami):
 
 ~~~ corefile
 . {


### PR DESCRIPTION
Thank you for contributing to CoreDNS' website!

Note:

 *  All text listed in /plugins is a *copied* from
    [https://github.com/coredns/coredns/tree/master/plugin](https://github.com/coredns/coredns/tree/master/plugin).

 *  The release notes are *copied* from
    [https://github.com/coredns/coredns/tree/master/notes](https://github.com/coredns/coredns/tree/master/notes).

Any pull request that updates either of those should be *directed* to the CoreDNS repository:
[https://github.com/coredns/coredns](https://github.com/coredns/coredns) .
