### PR TITLE
Sync 1.5.0 release notes from coredns repository

### DIFF
--- a/content/blog/coredns-1.5.0.md
+++ b/content/blog/coredns-1.5.0.md
@@ -25,14 +25,21 @@ And a update on two important and active bugs:
 
 # Plugins
 
-* a new [*ready*](/plugins/ready) was added that signals a plugin is ready to receive queries. First user is the *kubernetes* plugin.
-* a new [*grpc*](/plugins/grpc) was added to implement forwarding gRPC. If you were relying on this in the [*proxy*](/explugins/proxy) you can migrate to this one.
-* the [*cancel*](/plugins/cancel) was added that adds a context.WithTimeout to each context (but not
+* The [*ready*](/plugins/ready) plugin was added that signals a plugin is ready to receive queries. First user is the *kubernetes* plugin.
+* The [*grpc*](/plugins/grpc) plugin was added to implement forwarding gRPC. If you were relying on this in the [*proxy*](/explugins/proxy) you can migrate to this one.
+* The [*cancel*](/plugins/cancel) plugin was added that adds a context.WithTimeout to each context (but not
   enabled - yet).
-* the [*forward*](/plugins/forward) adds dnstap support.
-* the [*route53*](/plugins/route53) now supports wildcards.
-* the [*pprof*](/plugins/pprof) adds a `block` option that enables the block profiling.
-* the [*prometheus*](/plugins/metrics)  adds a `coredns_plugin_enabled` metric that shows which plugins are enabled.
+* The [*forward*](/plugins/forward) plugin adds dnstap support.
+* The [*route53*](/plugins/route53) plugin now supports wildcards.
+* The [*pprof*](/plugins/pprof) plugin adds a `block` option that enables the block profiling.
+* The [*prometheus*](/plugins/metrics) plugin  adds a `coredns_plugin_enabled` metric that shows which plugins are enabled.
+* The [*chaos*](/plugins/chaos) plugin returns the maintainers when queried for "authors.bind TXT CH".
+* The `resyncperiod` option in [*kubernetes*](/plugins/kubernetes) now defaults to zero seconds, which disables resyncing.
+
+# Deprecations
+
+* The `resyncperiod` option in [*kubernetes*](/plugins/kubernetes) is deprecated
+  and will be made a no-op in 1.6.0 and removed in 1.7.0.
 
 ## Brought to You By
 
@@ -43,6 +50,7 @@ dilyevsky,
 Francois Tur,
 Iñigo,
 Jiacheng Xu,
+John Belamaric,
 Matt Greenfield,
 MengZeLee,
 Miek Gieben,


### PR DESCRIPTION
Thank you for contributing to CoreDNS' website!

Note:

 *  All text listed in /plugins is a *copied* from
    [https://github.com/coredns/coredns/tree/master/plugin](https://github.com/coredns/coredns/tree/master/plugin).

 *  The release notes are *copied* from
    [https://github.com/coredns/coredns/tree/master/notes](https://github.com/coredns/coredns/tree/master/notes).

Any pull request that updates either of those should be *directed* to the CoreDNS repository:
[https://github.com/coredns/coredns](https://github.com/coredns/coredns) .
