### PR TITLE
Replace shutdown.md with example.md in explugin howto

### DIFF
--- a/content/blog/add-external.md
+++ b/content/blog/add-external.md
@@ -32,8 +32,8 @@ The *<plugin name>* plugin is a ...
 ## Example
 ~~~
 
-See [shutdown.md for an example]
-(https://raw.githubusercontent.com/coredns/coredns.io/master/content/explugins/shutdown.md)
+See [example.md for an example]
+(https://raw.githubusercontent.com/coredns/coredns.io/master/content/explugins/example.md)
 on how to do this.
 
 Note that **description** needs to be a full sentence, and that **repo** must be a Go-gettable link


### PR DESCRIPTION
shutdown.md was removed in 2dc1d6fd393886ba2a101210511f83ff7162b3f9#diff-d53be10beac06f907d863c77bb625a27 so link is now 404, this replaces it with a suitably example-y example.md
