### PR TITLE
 Auto build and deploy via Netlify

### DIFF
--- a/.github/workflows/sync.coredns.yml
+++ b/.github/workflows/sync.coredns.yml
@@ -20,6 +20,7 @@ jobs:
         name: Cleanup
         run: |
           rm -f content/plugins/*
+          rm -rf public/*
       -
         name: Sync
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .coredns
+public

--- a/.netlify.toml
+++ b/.netlify.toml
@@ -1,0 +1,13 @@
+[build]
+  publish = "public"
+  command = "hugo"
+
+[context.production.environment]
+  HUGO_VERSION = "0.62.2"
+  HUGO_ENV = "make"
+
+[context.deploy-preview]
+  command = "make"
+
+[context.deploy-preview.environment]
+  HUGO_VERSION = "0.62.2"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+all:
+	hugo -d public/
+
 .PHONY: deps
 deps:
 	go get github.com/miekg/corecheck

--- a/layouts/partials/stale.html
+++ b/layouts/partials/stale.html
@@ -1,6 +1,6 @@
 
 <!-- if the post's date is 9 month (-9) in the past pop up a banner
-     that is may be stale. Only done for posts that are tagged with
+     that says it may be stale. Only done for posts that are tagged with
      'stale' tag -->
 {{ if (.Date) "le" (now.AddDate 0 -9 0) }}
 

--- a/themes/coredns/layouts/partials/footer.html
+++ b/themes/coredns/layouts/partials/footer.html
@@ -38,7 +38,6 @@
 <p>
     <a href="https://github.com/coredns/coredns.io">Built</a> with
     <a href="https://gohugo.io">Hugo</a>. Resolved via
-    <a href="https://coredns.io">CoreDNS</a>. Served from <a
-        href="https://caddyserver.com">Caddy</a>.<br/>
-    <span class="smaller">It basically is <a href="https://golang.org">Go</a> all the way down.</span>
+    <a href="https://coredns.io">CoreDNS</a>. Served with Netlify.<br/>
+    <span class="smaller">It basically is <a href="https://golang.org">Go</a> almost all the way down.</span>
 </p>


### PR DESCRIPTION
This adds all remaining configuration to auto build and deploy
via Netlify. In addition to deploying master it also enables PR
review deploys.

It builds up on #178, but happy to rebase after #178 is merged.