### PR TITLE
Fix forced update due to cleanup removing ref data

### DIFF
--- a/.github/workflows/sync.coredns.yml
+++ b/.github/workflows/sync.coredns.yml
@@ -19,7 +19,6 @@ jobs:
       -
         name: Cleanup
         run: |
-          rm -f content/plugins/*
           rm -rf public/*
       -
         name: Sync


### PR DESCRIPTION
The cleanup job removed my used reference data. All tests locally worked, cause the cleanup ran in the workflow now in the sync run. Due to us removing old files within our sync code the separate cleanup shouldn't be necessary in the github workflow.
