### PR TITLE
Add redirects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 all:
 	hugo -d public/
+	cp _redirects public/
 
 .PHONY: deps
 deps:

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,4 @@
+https://coredns.io/* https://about.coredns.io/:splat 301!
+https://www.coredns.io/* https://about.coredns.io/:splat 301!
+https://coredns.netlify.com/* https://about.coredns.io/:splat 301!
+https://coredns.netlify.app/* https://about.coredns.io/:splat 301!


### PR DESCRIPTION
Add netlify redirects in preparation for switching to netlify:
Full domain redirects aka URI persists.

coredns.io -> about.coredns.io
www.coredns.io -> about.coredns.io
coredns.netlify.com -> about.coredns.io
coredns.netlify.app -> about.coredns.io