### PR TITLE
docs: Add `mdns` plugin

### DIFF
--- a/content/explugins/mdns.md
+++ b/content/explugins/mdns.md
@@ -1,0 +1,92 @@
++++
+title = "mdns"
+description = "*mdns* - serves '.local' mDNS info over normal DNS."
+weight = 10
+tags = [  "plugin" , "mdns" ]
+categories = [ "plugin", "external" ]
+date = "2020-06-17T11:07:00+12:00"
+repo = "https://github.com/openshift/coredns-mdns"
+home = "https://github.com/openshift/coredns-mdns/blob/master/README.md"
++++
+
+## Description
+
+This plugin reads mDNS records from the local network and responds to queries based on those records.
+
+Useful for providing mDNS records to non-mDNS-aware applications by making them accessible through a standard DNS server.
+
+## Syntax
+
+~~~ txt
+mdns example.com [minimum SRV records] [filter text] [bind address]
+~~~
+
+## Examples
+
+As a prerequisite to using this plugin, there must be systems on the local
+network broadcasting mDNS records. Note that the .local domain will be
+replaced with the configured domain. For example, `test.local` would become
+`test.example.com` using the configuration below.
+
+Specify the domain for the records.
+
+~~~ corefile
+example.com {
+	mdns example.com
+}
+~~~
+
+And test with `dig`:
+
+~~~ txt
+dig @localhost baremetal-test-extra-1.example.com
+
+;; ANSWER SECTION:
+baremetal-test-extra-1.example.com. 60 IN A   12.0.0.24
+baremetal-test-extra-1.example.com. 60 IN AAAA fe80::f816:3eff:fe49:19b3
+~~~
+
+If `minimum SRV records` is specified in the configuration, the plugin will wait
+until it has at least that many SRV records before responding with any of them.
+`minimum SRV records` defaults to `3`.
+
+~~~ corefile
+example.com {
+    mdns example.com 2
+}
+~~~
+
+This would mean that at least two SRV records of a given type would need to be
+present for any SRV records to be returned. If only one record is found, any
+requests for that type of SRV record would receive no results.
+
+If `filter text` is specified in the configuration, the plugin will ignore any
+mDNS records that do not include the specified text in the service name. This
+allows the plugin to be used in environments where there may be mDNS services
+advertised that are not intended for use with it. When `filter text` is not
+set, all records will be processed.
+
+~~~ corefile
+example.com {
+    mdns example.com 3 my-id
+}
+~~~
+
+This configuration would ignore any mDNS records that do not contain the
+string "my-id" in their service name.
+
+If `bind address` is specified in the configuration, the plugin will only send
+mDNS traffic to the associated interface. This prevents sending multicast
+packets on interfaces where that may not be desirable. To use `bind address`
+without setting a filter, set `filter text` to "".
+
+~~~ corefile
+example.com {
+    mdns example.com 3 "" 192.168.1.1
+}
+~~~
+
+This configuration will only send multicast packets to the interface assigned
+the `192.168.1.1` address. The interface lookup is dynamic each time an mDNS
+query is sent, so if the address moves to a different interface the plugin
+will automatically switch to the new one.


### PR DESCRIPTION
There's been discussion and attempts in the past about adding some form of mDNS support to CoreDNS, but those didn't pan out. OpenShift organization developed a plugin to discover services over mDNS `local` domain, originally it was internal to their fork, but they extracted it into an external plugin. 

There's been some efforts to raise awareness of it and list it on the official site as an external plugin for better awareness, but copy/pasting a README and updating a few bits of metadata was too high of an effort threshold for most to bother with :sweat_smile: Looks simple enough, so I've put this together for the benefit of others (I'm only aware of this plugin for CoreDNS and another for Unbound, this would have been something I'd like to have been easier to discover when I was looking).

As mentioned, I've for the most part done a direct copy/paste of the README content from the plugin repo, seems to be in the same expected format. I wasn't sure where the `date` value is meant to be sourced from, so I used the latest `master` commit date from the plugin repo. I also have no clue what `weight` is for, I checked a few plugins randomly and they all used the same value of `10`, so I've left that as-is. You could better document these metadata fields as the [current guide](https://coredns.io/2017/07/23/add-external-plugins/) is a bit vague on the matter.

---

The README does fail to mention some specifics required for it to work. It doesn't seem to forward/proxy to mDNS, but rather via polling interval, discover mDNS hosts that are published to a `_workstation._tcp` service, only those will be compatible with the plugin. [I have a PR to clarify that on their README](https://github.com/openshift/coredns-mdns/pull/64), along with some troubleshooting specifics with Avahi. Not sure how much of that will be merged, and how acceptable it is to maintain docs that differ from the plugin repo README.

They provide an `example.org` block, such that `www.example.org` would be equivalent to `www.local`, for my use case it was to let Android Chrome utilize `.local` mdns addresses, not sure how clear/obvious that is meant to seem to the plugin or CoreDNS maintainers, but as a new user that just required:

```
local {
    mdns local
}
```

Where you're responding to `*.local`, and the bit after `mdns` is removing `.local`(or whatever the value is) from the hostname to match the hostname value in the mDNS service response (an FQDN, typically ending with `.local` TLD).

I might publish an image on DockerHub, since not everyone may want to clone CoreDNS and compile it just to try the plugin out, the docs regarding that also left me a bit confused and reluctant initially. Not sure if that would be relevant/accepted to link to from this explugin doc?

---

Noting the below for the benefit of anyone else diving into using mDNS and coming across CoreDNS as a potential solution, following gotchas presently exist:

There is some weird behavior if deviating from standard mDNS `.local` TLD which [I raised an issue on the plugin repo](https://github.com/openshift/coredns-mdns/issues/63).

There's no way to alias/flatten additional labels for wildcard addressing the mDNS hostname, which also is deviating from standard usage of explicitly publishing aliases (but that can be a hassle in comparison). Previously [attempted as a PR of the `rewrite` plugin](https://github.com/coredns/coredns/pull/3273), but that likewise didn't pan out. Discussion continued on [it's related issue](https://github.com/coredns/coredns/issues/2389#issuecomment-683241728)

---

Original submission: https://github.com/coredns/coredns/pull/2832 (2019)
Fixes: https://github.com/coredns/coredns.io/issues/194 (May 2020)

Related feature requests for mdns server/proxy:

- Fixes: https://github.com/coredns/coredns/issues/317 (2016)
- Fixes: https://github.com/coredns/coredns/issues/1519 (2018)
- Fixes: https://github.com/coredns/coredns/issues/2557 (2019 - appears to be author/maintainer of this plugin)

[Related 2018 attempt at a internal plugin](https://github.com/coredns/coredns/pull/2233).

# TL;DR:

The struggle for adding the `mdns` external plugin to the main site for better discoverability is finally over! :grinning: 

It works reasonably well, despite some gripes above mostly related to non-standard scenarios or configuration required elsewhere. Thanks to devs of `coredns-mdns` and CoreDNS for making this relatively easy to setup and use!