### PR TITLE
Fix typo (CGP instead of GCP) in index.html

### DIFF
--- a/themes/coredns/layouts/index.html
+++ b/themes/coredns/layouts/index.html
@@ -91,7 +91,7 @@
         <a href="/plugins/kubernetes/">Kubernetes plugin</a>,
         or with <a href="https://coreos.com/etcd/">etcd</a> with the
         <a href="/plugins/etcd/">etcd plugin</a>. All major cloud providers have plugins too:
-        <a href="/plugins/azure">Microsoft Azure DNS</a>, <a href="/plugins/clouddns">CGP Cloud DNS</a> and
+        <a href="/plugins/azure">Microsoft Azure DNS</a>, <a href="/plugins/clouddns">GCP Cloud DNS</a> and
         <a href="/plugins/route53">AWS Route53</a>.
         </p>
       </div>


### PR DESCRIPTION

This fixes #218 
