### PR TITLE
enable unsecure commands

### DIFF
--- a/.github/workflows/check.corefile.yml
+++ b/.github/workflows/check.corefile.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    env:
+      ACTION_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - 
         name: Checkout


### PR DESCRIPTION
```Error: Unable to process command '::set-env name=GOPATH::/home/runner/go' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::add-path::/home/runner/go/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/```