### PR TITLE
replace unsecure commands

### DIFF
--- a/.github/workflows/check.corefile.yml
+++ b/.github/workflows/check.corefile.yml
@@ -22,8 +22,8 @@ jobs:
       -
         name: Setup Go Env
         run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "name=GOPATH::$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
       -
         name: Deps


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

related issue: https://github.com/coredns/coredns.io/runs/2661088131?check_suite_focus=true