### PR TITLE
corecheck: fix some Corefiles

### DIFF
--- a/content/blog/custom-dns-and-kubernetes.md
+++ b/content/blog/custom-dns-and-kubernetes.md
@@ -37,7 +37,7 @@ used in the last blog:
     log
     health
     kubernetes cluster.local 10.0.0.0/24
-    proxy . /etc/resolv.conf
+    forward . /etc/resolv.conf
     cache 30
 }
 ~~~
@@ -51,7 +51,7 @@ To get the behavior we want, we just need to add a rewrite rule mapping `foo.exa
     health
     rewrite name foo.example.com foo.default.svc.cluster.local
     kubernetes cluster.local 10.0.0.0/24
-    proxy . /etc/resolv.conf
+    forward . /etc/resolv.conf
     cache 30
 }
 ~~~
@@ -105,7 +105,7 @@ data:
         rewrite name foo.example.com foo.default.svc.cluster.local
         kubernetes cluster.local 10.0.0.0/24
         file /etc/coredns/example.db example.org
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
         cache 30
     }
   example.db: |

--- a/content/blog/httpsproxy.md
+++ b/content/blog/httpsproxy.md
@@ -6,6 +6,8 @@ title = "DNS over HTTPS"
 author = "miek"
 +++
 
+> Note this requires the *proxy* plugin which has been deprecated.
+
 Since almost a year Google has a DNS service that can be queried over HTTPS:
 <https://dns.google.com>. This means your queries are encrypted and can only be seen by you (and
 Google(!)). Seeing all the press about the

--- a/content/blog/kubernetes-service-discovery-2.md
+++ b/content/blog/kubernetes-service-discovery-2.md
@@ -72,7 +72,7 @@ data:
         log
         health
         kubernetes cluster.local 10.3.0.0/24
-        proxy . /etc/resolv.conf
+        forward . /etc/resolv.conf
         cache 30
     }
 ---
@@ -162,7 +162,7 @@ previous blog post.
     log
     health
     kubernetes cluster.local 10.3.0.0/24
-    proxy . /etc/resolv.conf
+    forward . /etc/resolv.conf
     cache 30
 }
 ~~~


### PR DESCRIPTION
Mostly s/proxy/forward to make these Corefiles work in the current
age.

Signed-off-by: Miek Gieben <miek@miek.nl>
