### PR TITLE
Add rrl plugin

### DIFF
--- a/content/explugins/rrl.md
+++ b/content/explugins/rrl.md
@@ -7,7 +7,7 @@
  date = "2021-10-07T00:00:00+00:00"
  repo = "https://github.com/coredns/rrl"
  home = "https://github.com/coredns/rrl/blob/master/README.md"
- +++
++++
 
  ## Description
 


### PR DESCRIPTION
Adds the rrl plugin to external plugins page.

rrl implements BIND-style Response Rate Limiting to mitigate DNS amplification DDOS attacks.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>
