### PR TITLE
External multicluster plugin repo moved to coredns org

### DIFF
--- a/content/explugins/multicluster.md
+++ b/content/explugins/multicluster.md
@@ -5,8 +5,8 @@ weight = 10
 tags = [  "plugin" , "multicluster" ]
 categories = [ "plugin", "external" ]
 date = "2021-11-09T12:37:19+01:00"
-repo = "https://github.com/vanekjar/coredns-multicluster/"
-home = "https://github.com/vanekjar/coredns-multicluster#readme"
+repo = "https://github.com/coredns/multicluster/"
+home = "https://github.com/coredns/multicluster#readme"
 +++
 
 ## Description


### PR DESCRIPTION
External multicluster plugin repo has been moved to coredns org, see https://github.com/coredns/multicluster/