### PR TITLE
update ext-pluging kubenodes syntax

### DIFF
--- a/content/explugins/kubenodes.md
+++ b/content/explugins/kubenodes.md
@@ -12,7 +12,11 @@ home = "https://github.com/infobloxopen/kubenodes/blob/main/README.md"
 ## Description
 
 *kubenodes* watches the Kubernetes API and synthesizes A, AAAA, and PTR records for Node addresses.
-This plugin requires list/watch permission to the Nodes API.
+
+This plugin requires ...
+* the [_kubeapi_ plugin](http://github.com/coredns/kubeapi) to create a connection
+  to the Kubernetes API.
+* list/watch permission to the Nodes API.
 
 This plugin can only be used once per Server Block.
 
@@ -21,23 +25,12 @@ This plugin can only be used once per Server Block.
 ```
 kubenodes [ZONES...] {
     external
-    endpoint URL
-    tls CERT KEY CACERT
-    kubeconfig KUBECONFIG [CONTEXT]
     ttl TTL
     fallthrough [ZONES...]
 }
 ```
 * `external` will build records using Nodes' external addresses.  If omitted, *kubenodes* will build records using
   Nodes' internal addresses.
-* `endpoint` specifies the **URL** for a remote k8s API endpoint.
-  If omitted, it will connect to k8s in-cluster using the cluster service account.
-* `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
-  This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
-* `kubeconfig` **KUBECONFIG [CONTEXT]** authenticates the connection to a remote k8s cluster using a kubeconfig file.
-  **[CONTEXT]** is optional, if not set, then the current context specified in kubeconfig will be used.
-  It supports TLS, username and password, or token-based authentication.
-  This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
 * `ttl` allows you to set a custom TTL for responses. The default is 5 seconds.  The minimum TTL allowed is
   0 seconds, and the maximum is capped at 3600 seconds. Setting TTL to 0 will prevent records from being cached.
   All endpoint queries and headless service queries will result in an NXDOMAIN.
@@ -48,9 +41,16 @@ kubenodes [ZONES...] {
   is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only
   queries for those zones will be subject to fallthrough.
 
+## External Plugin
+
+To use this plugin, compile CoreDNS with this plugin added to the `plugin.cfg`.  It should be positioned before
+the _kubernetes_ plugin if _kubenode_ is using the same zone or a superzone of _kubernetes_.  This plugin also requires
+the _kubeapi_ plugin, which should be added to the end of `plugin.cfg`.
+
 ## Ready
 
-This plugin reports that it is ready to the _ready_ plugin once it has synced to the Kubernetes API.
+This plugin reports that it is ready to the _ready_ plugin once it has received the complete list of Nodes
+from the Kubernetes API.
 
 ## Examples
 
@@ -58,6 +58,7 @@ Use Nodes' internal addresses to answer forward and reverse lookups in the zone 
 Fallthrough to the next plugin for reverse lookups that don't match any Nodes' internal IP addresses.
 
 ```
+kubeapi
 kubenodes node.cluster.local in-addr.arpa ip6.arpa {
   fallthrough in-addr.arpa ip6.arpa
 }
@@ -67,6 +68,7 @@ Use Nodes' external addresses to answer forward and reverse lookups in the zone 
 to the next plugin for reverse lookups that don't match any Nodes' external IP addresses.
 
 ```
+kubeapi
 kubenodes example in-addr.arpa ip6.arpa {
   external
   fallthrough in-addr.arpa ip6.arpa

--- a/content/explugins/kubenodes.md
+++ b/content/explugins/kubenodes.md
@@ -14,8 +14,7 @@ home = "https://github.com/infobloxopen/kubenodes/blob/main/README.md"
 *kubenodes* watches the Kubernetes API and synthesizes A, AAAA, and PTR records for Node addresses.
 
 This plugin requires ...
-* the _kubeapi_ plugin to create a connection (http://github.com/coredns/kubeapi)
-  to the Kubernetes API.
+* the _kubeapi_ plugin to create a connection to the Kubernetes API. (http://github.com/coredns/kubeapi)
 * list/watch permission to the Nodes API.
 
 This plugin can only be used once per Server Block.

--- a/content/explugins/kubenodes.md
+++ b/content/explugins/kubenodes.md
@@ -14,7 +14,7 @@ home = "https://github.com/infobloxopen/kubenodes/blob/main/README.md"
 *kubenodes* watches the Kubernetes API and synthesizes A, AAAA, and PTR records for Node addresses.
 
 This plugin requires ...
-* the [_kubeapi_ plugin](http://github.com/coredns/kubeapi) to create a connection
+* the _kubeapi_ plugin to create a connection (http://github.com/coredns/kubeapi)
   to the Kubernetes API.
 * list/watch permission to the Nodes API.
 


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

Updates _kubenodes_ syntax to latest version, which requires the _kubeapi_ plugin.
