### PR TITLE
Update for 1.9.3 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .coredns
 public
+/.hugo_build.lock

--- a/.netlify.toml
+++ b/.netlify.toml
@@ -3,11 +3,11 @@
   command = "hugo"
 
 [context.production.environment]
-  HUGO_VERSION = "0.62.2"
+  HUGO_VERSION = "0.100.2"
   HUGO_ENV = "make"
 
 [context.deploy-preview]
   command = "make"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.62.2"
+  HUGO_VERSION = "0.100.2"

--- a/content/blog/coredns-1.9.3.md
+++ b/content/blog/coredns-1.9.3.md
@@ -1,0 +1,31 @@
++++
+title = "CoreDNS-1.9.3 Release"
+description = "CoreDNS-1.9.3 Release Notes."
+tags = ["Release", "1.9.3", "Notes"]
+release = "1.9.3"
+date = "2022-05-27T00:00:00+00:00"
+author = "coredns"
++++
+
+This is a release with a focus on security (CVE-2022-27191 and CVE-2022-28948) fixes. Additionally,
+several feature enhancements and bug fixes have been added.
+
+## Brought to You By
+
+Chris O'Haver,
+lobshunter,
+Naveen,
+Radim Hatlapatka,
+RetoHaslerMGB,
+Tintin,
+Yong Tang
+
+
+## Noteworthy Changes
+
+* core: update gopkg.in/yaml.v3 to fix CVE-2022-28948 (https://github.com/coredns/coredns/pull/5408)
+* core: update golang.org/x/crypto to fix CVE-2022-27191 (https://github.com/coredns/coredns/pull/5407)
+* plugin/acl: adding a check to parse out zone info (https://github.com/coredns/coredns/pull/5387)
+* plugin/dnstap: support FQDN TCP endpoint (https://github.com/coredns/coredns/pull/5377)
+* plugin/errors: add `stacktrace` option to log a stacktrace during panic recovery (https://github.com/coredns/coredns/pull/5392)
+* plugin/template: return SERVFAIL for zone-match regex-no-match case (https://github.com/coredns/coredns/pull/5180)

--- a/content/plugins/cache.md
+++ b/content/plugins/cache.md
@@ -4,7 +4,7 @@ description = "*cache* enables a frontend cache."
 weight = 8
 tags = ["plugin", "cache"]
 categories = ["plugin"]
-date = "2022-05-10T17:23:06.877685"
+date = "2022-06-09T08:39:42.8774286"
 +++
 
 ## Description

--- a/content/plugins/dnstap.md
+++ b/content/plugins/dnstap.md
@@ -4,7 +4,7 @@ description = "*dnstap* enables logging to dnstap."
 weight = 15
 tags = ["plugin", "dnstap"]
 categories = ["plugin"]
-date = "2020-11-05T13:42:35.87735811"
+date = "2022-06-09T07:57:48.8774886"
 +++
 
 ## Description
@@ -42,6 +42,12 @@ Log to a remote endpoint.
 
 ~~~ txt
 dnstap tcp://127.0.0.1:6000 full
+~~~
+
+Log to a remote endpoint by FQDN.
+
+~~~ txt
+dnstap tcp://example.com:6000 full
 ~~~
 
 ## Command Line Tool

--- a/content/plugins/errors.md
+++ b/content/plugins/errors.md
@@ -4,7 +4,7 @@ description = "*errors* enables error logging."
 weight = 17
 tags = ["plugin", "errors"]
 categories = ["plugin"]
-date = "2021-09-21T15:01:04.877489"
+date = "2022-06-09T07:57:48.8774886"
 +++
 
 ## Description
@@ -25,9 +25,12 @@ Extra knobs are available with an expanded syntax:
 
 ~~~
 errors {
+	stacktrace
 	consolidate DURATION REGEXP [LEVEL]
 }
 ~~~
+
+Option `stacktrace` will log a stacktrace during panic recovery.
 
 Option `consolidate` allows collecting several error messages matching the regular expression **REGEXP** during **DURATION**. After the **DURATION** since receiving the first such message, the consolidated message will be printed to standard output with
 log level, which is configurable by optional option **LEVEL**. Supported options for **LEVEL** option are `warning`,`error`,`info` and `debug`.

--- a/content/plugins/forward.md
+++ b/content/plugins/forward.md
@@ -4,7 +4,7 @@ description = "*forward* facilitates proxying DNS messages to upstream resolvers
 weight = 20
 tags = ["plugin", "forward"]
 categories = ["plugin"]
-date = "2022-05-10T17:23:06.877685"
+date = "2022-06-09T07:57:48.8774886"
 +++
 
 ## Description
@@ -106,7 +106,7 @@ Also note the TLS config is "global" for the whole forwarding proxy if you need 
 
 On each endpoint, the timeouts for communication are set as follows:
 
-* The dial timeout by default is 30s, and can decrease automatically down to 100ms based on early results.
+* The dial timeout by default is 30s, and can decrease automatically down to 1s based on early results.
 * The read timeout is static at 2s.
 
 ## Metadata

--- a/content/plugins/template.md
+++ b/content/plugins/template.md
@@ -4,7 +4,7 @@ description = "*template* allows for dynamic responses based on the incoming que
 weight = 45
 tags = ["plugin", "template"]
 categories = ["plugin"]
-date = "2022-05-10T17:23:06.877685"
+date = "2022-06-09T07:57:48.8774886"
 +++
 
 ## Description
@@ -20,23 +20,24 @@ template CLASS TYPE [ZONE...] {
     additional RR
     authority RR
     rcode CODE
-    fallthrough [ZONE...]
+    fallthrough [FALLTHROUGH-ZONE...]
 }
 ~~~
 
 * **CLASS** the query class (usually IN or ANY).
 * **TYPE** the query type (A, PTR, ... can be ANY to match all types).
 * **ZONE** the zone scope(s) for this template. Defaults to the server zones.
-* **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no regex matches everything (default: `.*`). First matching regex wins.
+* `match` **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name.
+  Specifying no regex matches everything (default: `.*`). First matching regex wins.
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
-  built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
+  built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply. Specifying no answer will result
+  in a response with an empty answer section.
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `NOERROR`. Valid response code values are
   per the `RcodeToString` map defined by the `miekg/dns` package in `msg.go`.
-* `fallthrough` Continue with the next plugin if the zone matched but no regex matched.
-  If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only queries for
-  those zones will be subject to fallthrough.
-
-At least one `answer` or `rcode` directive is needed (e.g. `rcode NXDOMAIN`).
+* `fallthrough` Continue with the next _template_ instance if the _template_'s **ZONE** matches a query name but no regex match.
+  If there is no next _template_, continue resolution with the next plugin. If **[FALLTHROUGH-ZONE...]** are listed (for example
+  `in-addr.arpa` and `ip6.arpa`), then only queries for those zones will be subject to fallthrough. Without
+  `fallthrough`, when the _template_'s **ZONE** matches a query but no regex match then a `SERVFAIL` response is returned.
 
 [Also see](#also-see) contains an additional reading list.
 

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.9.2"
+  version = "1.9.3"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module coredns.io/internal/sync
 
-go 1.13
+go 1.17
 
-require github.com/BurntSushi/toml v0.3.1
+require github.com/BurntSushi/toml v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
+github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=

--- a/themes/coredns/layouts/_default/baseof.html
+++ b/themes/coredns/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}">
 
 <head>
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -25,9 +25,9 @@
   {{ if .IsHome }} {{ partial "site-verification" . }} {{ end }}
   <!-- add googleAnalytics in config.toml -->
   {{ template "_internal/google_analytics_async.html" . }}
-  {{ if .RSSLink }}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" /> {{ end }}
-
+  {{ with .OutputFormats.Get "rss" -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ end -}}
   <link rel="canonical" href="{{ .Permalink }}"> {{ if (isset .Params "prev") }}
   <link rel="prev" href="{{ .Params.prev }}"> {{ end }} {{ if (isset .Params "next") }}
   <link rel="next" href="{{ .Params.next }}"> {{ end }}

--- a/themes/coredns/layouts/index.html
+++ b/themes/coredns/layouts/index.html
@@ -17,7 +17,7 @@
       <p class="big">
         <span class="large">
          <a href="https://github.com/coredns/coredns/releases/latest">Version {{ .Params.release }}</a>. Released {{ dateFormat "2006-01-02" .Date }}.
-         <a href="{{ .URL }}">Release notes</a>.
+         <a href="{{ .RelPermalink }}">Release notes</a>.
         </span>
       </p>
       {{ end }}

--- a/themes/coredns/layouts/taxonomy/tag.html
+++ b/themes/coredns/layouts/taxonomy/tag.html
@@ -4,7 +4,7 @@
 {{ define "main" }}
 
 <div class="hero" class="wrap">
-    {{ $last := index (last 1 (split (delimit (split .URL "/") "," "") ",")) 0 }}
+    {{ $last := index (last 1 (split (delimit (split .Params.url "/") "," "") ",")) 0 }}
 
     <h1>{{ $last | humanize }}</h1>
     Tag: {{ $last }}.


### PR DESCRIPTION
* Update Hugo to 0.100.2.
* Fixup Hugo deprecation warnings.
* Sync plugin docs.
* Update sync tool Go modules.

Signed-off-by: SuperQ <superq@gmail.com>

Thank you for contributing to CoreDNS' website!

Note:

 *  All text listed in /plugins is a *copied* from
    [https://github.com/coredns/coredns/tree/master/plugin](https://github.com/coredns/coredns/tree/master/plugin).

 *  The release notes are *copied* from
    [https://github.com/coredns/coredns/tree/master/notes](https://github.com/coredns/coredns/tree/master/notes).

Any pull request that updates either of those should be *directed* to the CoreDNS repository:
[https://github.com/coredns/coredns](https://github.com/coredns/coredns) .
