### PR TITLE
Typo/grammar fix

### DIFF
--- a/content/manual/configuration.md
+++ b/content/manual/configuration.md
@@ -88,7 +88,7 @@ same port is an error. This Corefile will generate an error on startup:
 ~~~
 
 Changing the second port number to 1055 makes these Server Blocks two different Servers. Note that
-if you use the [*bind*](https://coredns.io/plugins/bind) you can have the same zone listening on the
+if you use the [*bind*](https://coredns.io/plugins/bind) plugin you can have the same zone listening on the
 *same* port, provided they are binded to *different* interfaces or IP addresses. The syntax used
  here is supported since CoreDNS 1.8.4.
 


### PR DESCRIPTION
It looks like the author meant to write "the bind plugin" or "bind," as opposed to "the bind."

Thank you for contributing to CoreDNS' website!

Note:

 *  All text listed in /plugins is a *copied* from
    [https://github.com/coredns/coredns/tree/master/plugin](https://github.com/coredns/coredns/tree/master/plugin).

 *  The release notes are *copied* from
    [https://github.com/coredns/coredns/tree/master/notes](https://github.com/coredns/coredns/tree/master/notes).

Any pull request that updates either of those should be *directed* to the CoreDNS repository:
[https://github.com/coredns/coredns](https://github.com/coredns/coredns) .
