### PR TITLE
Remove trailing slash on repository path in explugins/multicluster.md

### DIFF
--- a/content/explugins/multicluster.md
+++ b/content/explugins/multicluster.md
@@ -4,8 +4,8 @@ description = "*multicluster* plugin is an implementation of Multicluster DNS sp
 weight = 10
 tags = [  "plugin" , "multicluster" ]
 categories = [ "plugin", "external" ]
-date = "2021-11-09T12:37:19+01:00"
-repo = "https://github.com/coredns/multicluster/"
+date = "2023-03-03T03:51:43+00:00"
+repo = "https://github.com/coredns/multicluster"
 home = "https://github.com/coredns/multicluster#readme"
 +++
 


### PR DESCRIPTION
Attempting to include the multicluster plugin with the suggested plugin.cfg line of `multicluster:github.com/coredns/multicluster/` leads to a compile error:

```
core/plugin/zplugin.go:60:2: malformed import path "github.com/coredns/multicluster/": trailing slash
make[1]: *** [Makefile:16: coredns] Error 1
```

Removing the trailing slash fixes the issue and matches the format of the repository URLs on the other extplugins files.

Current site view:
![image](https://user-images.githubusercontent.com/3046014/222627312-a0467f5a-bc2f-46fc-b0cf-bb57d41ba851.png)
