### PR TITLE
note features that are not yet implemented

### DIFF
--- a/content/plugins/sign.md
+++ b/content/plugins/sign.md
@@ -74,7 +74,8 @@ sign DBFILE [ZONES...] {
 * `key` specifies the key(s) (there can be multiple) to sign the zone. If `file` is
    used the **KEY**'s filenames are used as is. If `directory` is used, *sign* will look in **DIR**
    for `K<name>+<alg>+<id>` files. Any metadata in these files (Activate, Publish, etc.) is
-   *ignored*. These keys must also be Key Signing Keys (KSK).
+   *ignored*. These keys must also be Key Signing Keys (KSK). (Please note that
+   `directory` is currently not implemented.)
 *  `directory` specifies the **DIR** where CoreDNS should save zones that have been signed.
    If not given this defaults to `/var/lib/coredns`. The zones are saved under the name
    `db.<name>.signed`. If the path is relative the path from the *root* plugin will be prepended

--- a/content/plugins/transfer.md
+++ b/content/plugins/transfer.md
@@ -36,7 +36,8 @@ transfer [ZONE...] {
  *  `to` **ADDRESS...** The hosts *transfer* will transfer to. Use `*` to permit transfers to all
     addresses. Zone change notifications are sent to all **ADDRESS** that are an IP address or
     an IP address and port e.g. `1.2.3.4`, `12:34::56`, `1.2.3.4:5300`, `[12:34::56]:5300`.
-    `to` may be specified multiple times.
+    `to` may be specified multiple times. (Please note that notifications is
+    currently not implemented.)
 
 You can use the _acl_ plugin to further restrict hosts permitted to receive a zone transfer.
 See example below.


### PR DESCRIPTION
I spent a long time trying to figure out why `key directory` wasn't working for signing, then realized that it was not yet implemented.
See: https://github.com/coredns/coredns/blob/93139841965d8a4e6791dbe2e4d154991fc6a59b/plugin/sign/keys.go#L62

I then also spent a long time trying to figure out why CoreDNS wasn't sending any notifications to secondary nameservers, then realized it also has not been implemented.
See: https://github.com/coredns/coredns/issues/5669

This PR aims to reduce user headache by clearly noting features that have not been implemented.