### PR TITLE
Fix "GitHub" capitalization

### DIFF
--- a/content/blog/coredns-and-caddy.md
+++ b/content/blog/coredns-and-caddy.md
@@ -14,8 +14,8 @@ Note that if you select this option you get a binary that is *both* a DNS and we
 startup you can select between the two with `-type=dns|http` flag.
 
 The CoreDNS developers will still provide their own (DNS only) binaries over [at
-github](https://github.com/coredns/coredns/releases).
+GitHub](https://github.com/coredns/coredns/releases).
 
 Note that we *also* have a CoreDNS category on the [Caddy
 forum](https://forum.caddyserver.com/c/coredns) where you can ask questions. Bugs and feature
-requests are probably better directed to our [github](https://github.com/coredns/coredns).
+requests are probably better directed to our [GitHub](https://github.com/coredns/coredns).

--- a/content/blog/cure53.md
+++ b/content/blog/cure53.md
@@ -23,7 +23,7 @@ CoreDNS 1.1.1 release):
 > inject malicious A records in the cache of the DNS server.
 > As the CoreDNS application has a different cache for each domain
 
-The other three issues found will be tracked via github issues, like
+The other three issues found will be tracked via GitHub issues, like
 [plugin/rewrite: log bypass](https://github.com/coredns/coredns/issues/1610), and
 [plugin/secondary: Denial-of-Service via endless Zone Transfer](plugin/secondary: Denial-of-Service
 via endless Zone Transfer). Third one was a generic DDoS.

--- a/content/blog/quick-start.md
+++ b/content/blog/quick-start.md
@@ -8,10 +8,10 @@ author = "miek"
 
 First get CoreDNS, either
 
-* *Download the latest* release from [github](https://github.com/coredns/coredns/releases), unpack
+* *Download the latest* release from [GitHub](https://github.com/coredns/coredns/releases), unpack
   it. You should now have a "coredns" executable.
 
-* *Compile from git* by getting the source code from [github](https://github.com/coredns/coredns).
+* *Compile from git* by getting the source code from [GitHub](https://github.com/coredns/coredns).
   Change directory to `coredns` and:
 
   * `go get` - to get a few dependencies, the other ones are vendored

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -4,7 +4,7 @@ title = "Community"
 
 **Mailing list**: [coredns-discuss@googlegroups.com](mailto:coredns-discuss@googlegroups.com) -
 discussion around CoreDNS usage, community support and developer discussion (*very* low traffic,
-most discussion happens on Github).
+most discussion happens on GitHub).
 
 **Slack**: #coredns on https://slack.cncf.io
 
@@ -24,7 +24,7 @@ We welcome community contributions! Please see the
 [`CONTRIBUTING.md`](https://github.com/coredns/coredns/blob/master/.github/CONTRIBUTING.md)
 file in the CoreDNS repository for instructions on how to submit changes. If you are planning
 on making more elaborate or controversial changes, please discuss them on the mailing list or on
-[Github](https://github.com/coredns/coredns/issues/new) before sending a pull request.
+[GitHub](https://github.com/coredns/coredns/issues/new) before sending a pull request.
 
 ## Project Governance
 CoreDNS is an independent open-source project and not controlled by any single company.

--- a/content/explugins/idetcd.md
+++ b/content/explugins/idetcd.md
@@ -37,7 +37,7 @@ $ go get -u github.com/jiachengxu/idetcd
 
 Before you move to the next step, make sure that you've **already set up a etcd instance**, and don't forget to write down the endpoints.
 
-Then you need to add a Corefile which specifys the configuration of the CoreDNS server in the same directory of `main.go`, a simple Corefile example is as follows, please go to [CoreDNS Github repo](https://github.com/coredns/coredns) for more details.
+Then you need to add a Corefile which specifys the configuration of the CoreDNS server in the same directory of `main.go`, a simple Corefile example is as follows, please go to [CoreDNS GitHub repo](https://github.com/coredns/coredns) for more details.
 
  ~~~ corefile
  . {

--- a/themes/coredns/layouts/index.html
+++ b/themes/coredns/layouts/index.html
@@ -10,7 +10,7 @@
 
   <div id="action-buttons">
       <a class="button primary big" href="https://github.com/coredns/coredns/releases/latest"><i class="fa fa-download"></i> Download</a>
-      <a class="button outline big" href="{{ .Site.Params.github }}"><i class="fa fa-github"></i> View on Github</a>
+      <a class="button outline big" href="{{ .Site.Params.github }}"><i class="fa fa-github"></i> View on GitHub</a>
       <a class="button outline big" href="/manual/toc/"><i class="fa fa-file-o"></i> Manual</a>
       <br/>
       {{ range where .Site.Pages "Params.release" "eq" .Site.Data.coredns.release.version }}
@@ -42,7 +42,7 @@
             CoreDNS is licensed under the
             <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License Version 2</a>, and completely open source.
             <br/>
-            Development takes place on <a href="https://github.com/coredns/coredns">Github</a>. Some devs hang
+            Development takes place on <a href="https://github.com/coredns/coredns">GitHub</a>. Some devs hang
             out on <a href="https://slack.cncf.io/">Slack</a> on the #coredns channel.
         </p>
       </div>

--- a/themes/coredns/layouts/manual/single.html
+++ b/themes/coredns/layouts/manual/single.html
@@ -10,7 +10,7 @@
   </div>
 
   <div id="action-buttons">
-      <a class="button primary big" href="{{ .Site.Params.manual }}"><i class="fa fa-github"></i> View on Github</a>
+      <a class="button primary big" href="{{ .Site.Params.manual }}"><i class="fa fa-github"></i> View on GitHub</a>
       <!-- Make a PDF out of this??? -->
       <!-- <a class="button primary big" href="https://github.com/coredns/coredns/releases/latest"><i class="fa fa-download"></i> Download</a> -->
  </div>

--- a/themes/coredns/layouts/partials/footer.html
+++ b/themes/coredns/layouts/partials/footer.html
@@ -2,7 +2,7 @@
     <ul>
         <li>
             <a href="{{ .Site.Params.github }}">
-                <i class="fa fa-github"></i> Github
+                <i class="fa fa-github"></i> GitHub
             </a>
         </li>
         <li>


### PR DESCRIPTION
Hello, this PR is just a small fix of the word "Github". The canonical spelling is "GitHub" instead of "Github".