### PR TITLE
chore: bump to v1.12.3

### DIFF
--- a/content/blog/coredns-1.12.3.md
+++ b/content/blog/coredns-1.12.3.md
@@ -1,0 +1,48 @@
++++
+title = "CoreDNS-1.12.3 Release"
+description = "CoreDNS-1.12.3 Release Notes."
+tags = ["Release", "1.12.3", "Notes"]
+release = "1.12.3"
+date = "2025-08-05T00:00:00+00:00"
+author = "coredns"
++++
+
+This release improves plugin reliability and standards compliance, adding startup timeout to the Kubernetes
+plugin, fallthrough to gRPC, and EDNS0 unset to rewrite. The file plugin now preserves SRV record case per
+RFC 6763, route53 is updated to AWS SDK v2, and multiple race conditions in cache and connection handling in
+forward are fixed.
+
+## Brought to You By
+
+blakebarnett
+Brennan Kinney
+Cameron Steel
+Dave Brown
+Dennis Simmons
+Guillaume Jacquet
+harshith-2411-2002
+houpo-bob
+Oleg Guba
+Sebastian Mayr
+Stephen Kitt
+Syed Azeez
+Ville Vesilehto
+Yong Tang
+Yoofi Quansah
+
+
+## Noteworthy Changes
+
+* plugin/auto: Return REFUSED when no next plugin is available (https://github.com/coredns/coredns/pull/7381)
+* plugin/cache: Create a copy of a response to ensure original msg is never modified (https://github.com/coredns/coredns/pull/7357)
+* plugin/cache: Fix data race when refreshing cached messages (https://github.com/coredns/coredns/pull/7398)
+* plugin/cache: Fix data race when updating the TTL of cached messages (https://github.com/coredns/coredns/pull/7397)
+* plugin/file: Return REFUSED when no next plugin is available (https://github.com/coredns/coredns/pull/7381)
+* plugin/file: Preserve case in SRV record names and targets per RFC 6763 (https://github.com/coredns/coredns/pull/7402)
+* plugin/forward: Handle cached connection closure in forward plugin (https://github.com/coredns/coredns/pull/7427)
+* plugin/grpc: Add support for fallthrough to the grpc plugin (https://github.com/coredns/coredns/pull/7359)
+* plugin/kubernetes: Add startup_timeout for kubernetes plugin (https://github.com/coredns/coredns/pull/7068)
+* plugin/kubernetes: Properly create hostname from IPv6 (https://github.com/coredns/coredns/pull/7431)
+* plugin/rewrite: Add EDNS0 unset action (https://github.com/coredns/coredns/pull/7380)
+* plugin/route53: Port to AWS Go SDK v2 (https://github.com/coredns/coredns/pull/6588)
+* plugin/test: Fix TXT record comparison logic for multi-string vs multi-record scenarios (https://github.com/coredns/coredns/pull/7413)

--- a/content/plugins/bind.md
+++ b/content/plugins/bind.md
@@ -4,7 +4,7 @@ description = "*bind* overrides the host to which the server should bind."
 weight = 6
 tags = ["plugin", "bind"]
 categories = ["plugin"]
-date = "2024-11-22T08:09:54.87754811"
+date = "2025-08-08T17:41:04.877488"
 +++
 
 ## Description
@@ -111,6 +111,3 @@ bad.example.com {
     forward . 5.6.7.8
 }
 ```
-
-Also on MacOS there is an (open) bug where this doesn't work properly. See
-<https://github.com/miekg/dns/issues/724> for details, but no solution.

--- a/content/plugins/kubernetes.md
+++ b/content/plugins/kubernetes.md
@@ -4,7 +4,7 @@ description = "*kubernetes* enables reading zone data from a Kubernetes cluster.
 weight = 28
 tags = ["plugin", "kubernetes"]
 categories = ["plugin"]
-date = "2025-06-13T10:26:16.8771686"
+date = "2025-08-08T17:41:04.877488"
 +++
 
 ## Description
@@ -46,6 +46,7 @@ kubernetes [ZONES...] {
     fallthrough [ZONES...]
     ignore empty_service
     multicluster [ZONES...]
+    startup_timeout DURATION
 }
 ```
 
@@ -109,6 +110,8 @@ kubernetes [ZONES...] {
   Services API (MCS-API). Specifying this option is generally paired with the
   installation of an MCS-API implementation and the ServiceImport and ServiceExport
   CRDs. The plugin MUST be authoritative for the zones listed here.
+* `startup_timeout` specifies the **DURATION** value that limits the time to wait for informer cache synced
+  when the kubernetes plugin starts. If not specified, the default timeout will be 5s.
 
 Enabling zone transfer is done by using the *transfer* plugin.
 
@@ -118,7 +121,7 @@ When CoreDNS starts with the *kubernetes* plugin enabled, it will delay serving 
 until it can connect to the Kubernetes API and synchronize all object watches.  If this cannot happen within
 5 seconds, then CoreDNS will start serving DNS while the *kubernetes* plugin continues to try to connect
 and synchronize all object watches.  CoreDNS will answer SERVFAIL to any request made for a Kubernetes record
-that has not yet been synchronized.
+that has not yet been synchronized. You can also determine how long to wait by specifying `startup_timeout`.
 
 ## Monitoring Kubernetes Endpoints
 

--- a/content/plugins/rewrite.md
+++ b/content/plugins/rewrite.md
@@ -1,10 +1,10 @@
 +++
 title = "rewrite"
 description = "*rewrite* performs internal message rewriting."
-weight = 41
+weight = 42
 tags = ["plugin", "rewrite"]
 categories = ["plugin"]
-date = "2024-11-22T08:09:54.87754811"
+date = "2025-08-08T17:41:04.877488"
 +++
 
 ## Description
@@ -397,11 +397,12 @@ The values of FROM and TO can be any of the following, text value or numeric:
 
 ## EDNS0 Options
 
-Using the FIELD edns0, you can set, append, or replace specific EDNS0 options in the request.
+Using the FIELD edns0, you can set, append, replace, or unset specific EDNS0 options in the request.
 
 * `replace` will modify any "matching" option with the specified option. The criteria for "matching" varies based on EDNS0 type.
 * `append` will add the option only if no matching option exists
 * `set` will modify a matching option or add one if none is found
+* `unset` will remove the matching option if one exists
 
 Currently supported are `EDNS0_LOCAL`, `EDNS0_NSID` and `EDNS0_SUBNET`.
 
@@ -447,10 +448,17 @@ some-plugin
 rewrite edns0 local set 0xffee {some-plugin/some-label}
 ~~~
 
+A local option may be removed by unsetting its code. Example:
+
+~~~
+rewrite edns0 local unset 0xffee
+~~~
+
 ### EDNS0_NSID
 
 This has no fields; it will add an NSID option with an empty string for the NSID. If the option already exists
 and the action is `replace` or `set`, then the NSID in the option will be set to the empty string.
+The option can be removed with the `unset` action.
 
 ### EDNS0_SUBNET
 
@@ -465,6 +473,12 @@ rewrite edns0 subnet set 24 56
 
 * If the query's source IP address is an IPv4 address, the first 24 bits in the IP will be the network subnet.
 * If the query's source IP address is an IPv6 address, the first 56 bits in the IP will be the network subnet.
+
+This option can be removed by using `unset`:
+
+~~~
+rewrite edns0 subnet unset
+~~~
 
 ### EDNS0 Revert
 

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.12.2"
+  version = "1.12.3"


### PR DESCRIPTION
Thank you for contributing to CoreDNS' website!

Note:

 *  All text listed in /plugins is a *copied* from
    [https://github.com/coredns/coredns/tree/master/plugin](https://github.com/coredns/coredns/tree/master/plugin).

 *  The release notes are *copied* from
    [https://github.com/coredns/coredns/tree/master/notes](https://github.com/coredns/coredns/tree/master/notes).

Any pull request that updates either of those should be *directed* to the CoreDNS repository:
[https://github.com/coredns/coredns](https://github.com/coredns/coredns) .
