### PR TITLE
chore: bump to v1.12.4

### DIFF
--- a/content/blog/coredns-1.12.4.md
+++ b/content/blog/coredns-1.12.4.md
@@ -1,0 +1,39 @@
++++
+title = "CoreDNS-1.12.4 Release"
+description = "CoreDNS-1.12.4 Release Notes."
+tags = ["Release", "1.12.4", "Notes"]
+release = "1.12.4"
+date = "2025-09-08T00:00:00+00:00"
+author = "coredns"
++++
+
+This release improves stability and security, fixing context propagation in DoH, label offset handling
+in the file plugin, and connection leaks in gRPC and transfer. It also adds support for the prefer option
+in loadbalance, introduces timeouts to the metrics server, and fixes several security vulnerabilities
+(see details in related security advisories).
+
+
+## Brought to You By
+
+Archy
+Ilya Kulakov
+Olli Janatuinen
+Qasim Sarfraz
+Syed Azeez
+Ville Vesilehto
+wencyu
+Yong Tang
+
+
+## Noteworthy Changes
+
+* core: Improve caddy.GracefulServer conformance checks (https://github.com/coredns/coredns/pull/7416)
+* core: Propagate HTTP request context in DoH (https://github.com/coredns/coredns/pull/7491)
+* plugin/file: Fix label offset problem in ClosestEncloser (https://github.com/coredns/coredns/pull/7465)
+* plugin/grpc: Check proxy list length in policies (https://github.com/coredns/coredns/pull/7512)
+* plugin/grpc: Fix span leak and deadline on error attempt (https://github.com/coredns/coredns/pull/7487)
+* plugin/header: Remove deprecated syntax (https://github.com/coredns/coredns/pull/7436)
+* plugin/loadbalance: Support prefer option (https://github.com/coredns/coredns/pull/7433)
+* plugin/metrics: Add timeouts to metrics HTTP server (https://github.com/coredns/coredns/pull/7469)
+* plugin/trace: Migrate dd-trace-go v1 to v2 (https://github.com/coredns/coredns/pull/7466)
+* plugin/transfer: Fix goroutine leak on axfr err (https://github.com/coredns/coredns/pull/7516)

--- a/content/plugins/etcd.md
+++ b/content/plugins/etcd.md
@@ -4,7 +4,7 @@ description = "*etcd* enables SkyDNS service discovery from etcd."
 weight = 18
 tags = ["plugin", "etcd"]
 categories = ["plugin"]
-date = "2023-02-07T20:00:01.877182"
+date = "2025-09-09T18:54:52.8775289"
 +++
 
 ## Description
@@ -58,6 +58,8 @@ etcd [ZONES...] {
     * three arguments - path to cert PEM file, path to client private key PEM file, path to CA PEM
       file - if the server certificate is not signed by a system-installed CA and client certificate
       is needed.
+* `min-lease-ttl` the minimum TTL for DNS records based on etcd lease duration. Accepts flexible time formats like '30', '30s', '5m', '1h', '2h30m'. Default: 30 seconds.
+* `max-lease-ttl` the maximum TTL for DNS records based on etcd lease duration. Accepts flexible time formats like '30', '30s', '5m', '1h', '2h30m'. Default: 24 hours.
 
 ## Special Behaviour
 
@@ -86,6 +88,8 @@ skydns.local {
     etcd {
         path /skydns
         endpoint http://localhost:2379
+        min-lease-ttl 60     # minimum 1 minute for lease-based records
+        max-lease-ttl 1h     # maximum 1 hour for lease-based records
     }
     prometheus
     cache

--- a/content/plugins/header.md
+++ b/content/plugins/header.md
@@ -4,7 +4,7 @@ description = "*header* modifies the header for queries and responses."
 weight = 23
 tags = ["plugin", "header"]
 categories = ["plugin"]
-date = "2022-09-08T18:42:54.8775489"
+date = "2025-09-09T18:54:52.8775289"
 +++
 
 ## Description
@@ -16,12 +16,12 @@ The modifications are made transparently for the client and subsequent plugins.
 
 ~~~
 header {
-    [SELECTOR] ACTION FLAGS...
-    [SELECTOR] ACTION FLAGS...
+    SELECTOR ACTION FLAGS...
+    SELECTOR ACTION FLAGS...
 }
 ~~~
 
-* **SELECTOR** defines if the action should be applied on `query` or `response`. In future CoreDNS version the selector will be mandatory. For backwards compatibility the action will be applied on `response` if the selector is undefined.
+* **SELECTOR** defines if the action should be applied on `query` or `response`.
 
 * **ACTION** defines the state for DNS message header flags. Actions are evaluated in the order they are defined so last one has the
   most precedence. Allowed values are:

--- a/content/plugins/kubernetes.md
+++ b/content/plugins/kubernetes.md
@@ -4,7 +4,7 @@ description = "*kubernetes* enables reading zone data from a Kubernetes cluster.
 weight = 28
 tags = ["plugin", "kubernetes"]
 categories = ["plugin"]
-date = "2025-08-08T17:41:04.877488"
+date = "2025-09-09T19:02:11.8771189"
 +++
 
 ## Description

--- a/content/plugins/loadbalance.md
+++ b/content/plugins/loadbalance.md
@@ -1,10 +1,10 @@
 +++
 title = "loadbalance"
-description = "*loadbalance* randomizes the order of A, AAAA and MX records."
+description = "*loadbalance* randomizes the order of A, AAAA and MX records  and optionally prefers specific subnets."
 weight = 29
 tags = ["plugin", "loadbalance"]
 categories = ["plugin"]
-date = "2023-02-07T20:00:01.877182"
+date = "2025-09-09T18:54:52.8775289"
 +++
 
 ## Description
@@ -21,6 +21,7 @@ implementations (like glibc) are particular about that.
 ~~~
 loadbalance [round_robin | weighted WEIGHTFILE] {
 			reload DURATION
+			prefer CIDR [CIDR...]
 }
 ~~~
 * `round_robin` policy randomizes the order of  A, AAAA, and MX records applying a uniform probability distribution. This is the default load balancing policy.
@@ -28,6 +29,8 @@ loadbalance [round_robin | weighted WEIGHTFILE] {
 * `weighted` policy assigns weight values to IPs to control the relative likelihood of particular IPs to be returned as the first
 (top) A/AAAA record in the answer. Note that it does not shuffle all the records in the answer, it is only concerned about the first A/AAAA record
 returned in the answer.
+
+Additionally, the plugin supports subnet-based ordering using the `prefer` directive, which reorders A/AAAA records so that IPs from preferred subnets appear first.
 
  * **WEIGHTFILE** is the file containing the weight values assigned to IPs for various domain names. If the path is relative, the path from the **root** plugin will be prepended to it. The format is explained below in the *Weightfile* section.
 
@@ -91,3 +94,17 @@ www.example.com
 100.64.1.3 2
 ~~~
 
+### Subnet Prioritization
+
+Prioritize IPs from 10.9.20.0/24 and 192.168.1.0/24:
+
+```corefile
+. {
+    loadbalance round_robin {
+        prefer 10.9.20.0/24 192.168.1.0/24
+    }
+    forward . 1.1.1.1
+}
+```
+
+If the DNS response includes multiple A/AAAA records, the plugin will reorder them to place the ones matching preferred subnets first.

--- a/content/plugins/ready.md
+++ b/content/plugins/ready.md
@@ -4,7 +4,7 @@ description = "*ready* enables a readiness check HTTP endpoint."
 weight = 40
 tags = ["plugin", "ready"]
 categories = ["plugin"]
-date = "2025-06-13T10:26:16.8771686"
+date = "2025-09-09T19:01:00.877089"
 +++
 
 ## Description

--- a/content/plugins/rewrite.md
+++ b/content/plugins/rewrite.md
@@ -4,7 +4,7 @@ description = "*rewrite* performs internal message rewriting."
 weight = 42
 tags = ["plugin", "rewrite"]
 categories = ["plugin"]
-date = "2025-08-08T17:41:04.877488"
+date = "2025-09-09T19:01:00.877089"
 +++
 
 ## Description

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.12.3"
+  version = "1.12.4"


### PR DESCRIPTION
Thank you for contributing to CoreDNS' website!

Note:

 *  All text listed in /plugins is a *copied* from
    [https://github.com/coredns/coredns/tree/master/plugin](https://github.com/coredns/coredns/tree/master/plugin).

 *  The release notes are *copied* from
    [https://github.com/coredns/coredns/tree/master/notes](https://github.com/coredns/coredns/tree/master/notes).

Any pull request that updates either of those should be *directed* to the CoreDNS repository:
[https://github.com/coredns/coredns](https://github.com/coredns/coredns) .
