### PR TITLE
chore: bump to v1.13.2

### DIFF
--- a/content/blog/coredns-1.13.2.md
+++ b/content/blog/coredns-1.13.2.md
@@ -1,0 +1,68 @@
++++
+title = "CoreDNS-1.13.2 Release"
+description = "CoreDNS-1.13.2 Release Notes."
+tags = ["Release", "1.13.2", "Notes"]
+release = "1.13.2"
+date = "2025-12-08T00:00:00+00:00"
+author = "coredns"
++++
+
+This release adds initial support for DoH3 and includes several core performance and stability
+fixes, including reduced allocations, a resolved data race in uniq, and safer QUIC listener
+initialization. Plugin updates improve forwarder reliability, extend GeoIP schema support,
+and fix issues in secondary, nomad, and kubernetes. Cache and file plugins also receive
+targeted performance tuning.
+
+Deprecations: The GeoIP plugin currently returns 0 for missing latitude/longitude, even though
+0,0 is a real location. In the next release, this behavior will change: missing coordinates
+will return an empty string instead. This avoids conflating “missing” with a real coordinate.
+Users relying on 0 as a sentinel value should update their logic before this change takes effect.
+See PR #7732 for reference.
+
+## Brought to You By
+
+Alicia Y
+Andrey Smirnov
+Brennan Kinney
+Charlie Vieth
+Endre Szabo
+Eric Case
+Filippo125
+Nico Berlee
+Olli Janatuinen
+Rick Fletcher
+Timur Solodovnikov
+Tomas Boros
+Ville Vesilehto
+cangming
+rpb-ant
+wencyu
+wenxuan70
+Yong Tang
+zhetaicheleba
+
+## Noteworthy Changes
+
+* core: Add basic support for DoH3 (https://github.com/coredns/coredns/pull/7677)
+* core: Avoid proxy unnecessary alloc in Yield (https://github.com/coredns/coredns/pull/7708)
+* core: Fix usage of sync.Pool to save an alloc (https://github.com/coredns/coredns/pull/7701)
+* core: Fix data race with sync.RWMutex for uniq (https://github.com/coredns/coredns/pull/7707)
+* core: Prevent QUIC reload panic by lazily initializing the listener (https://github.com/coredns/coredns/pull/7680)
+* core: Refactor/use reflect.TypeFor (https://github.com/coredns/coredns/pull/7696)
+* plugin/auto: Limit regex length (https://github.com/coredns/coredns/pull/7737)
+* plugin/cache: Remove superfluous allocations in item.toMsg (https://github.com/coredns/coredns/pull/7700)
+* plugin/cache: Isolate metadata in prefetch goroutine (https://github.com/coredns/coredns/pull/7631)
+* plugin/cache: Correct spelling of MaximumDefaultTTL in cache and dnsutil packages (https://github.com/coredns/coredns/pull/7678)
+* plugin/dnstap: Better error handling (redial & logging) when Dnstap is busy (https://github.com/coredns/coredns/pull/7619)
+* plugin/file: Performance finetuning (https://github.com/coredns/coredns/pull/7658)
+* plugin/forward: Disallow NOERROR in failover (https://github.com/coredns/coredns/pull/7622)
+* plugin/forward: Added support for per-nameserver TLS SNI (https://github.com/coredns/coredns/pull/7633)
+* plugin/forward: Prevent busy loop on connection err (https://github.com/coredns/coredns/pull/7704)
+* plugin/forward: Add max connect attempts knob (https://github.com/coredns/coredns/pull/7722)
+* plugin/geoip: Add ASN schema support (https://github.com/coredns/coredns/pull/7730)
+* plugin/geoip: Add support for subdivisions (https://github.com/coredns/coredns/pull/7728)
+* plugin/kubernetes: Fix kubernetes plugin logging (https://github.com/coredns/coredns/pull/7727)
+* plugin/multisocket: Cap num sockets to prevent OOM (https://github.com/coredns/coredns/pull/7615)
+* plugin/nomad: Support service filtering (https://github.com/coredns/coredns/pull/7724)
+* plugin/rewrite: Pre-compile CNAME rewrite regexp (https://github.com/coredns/coredns/pull/7697)
+* plugin/secondary: Fix reload causing secondary plugin goroutine to leak (https://github.com/coredns/coredns/pull/7694)

--- a/content/plugins/auto.md
+++ b/content/plugins/auto.md
@@ -4,7 +4,7 @@ description = "*auto* enables serving zone data from an RFC 1035-style master fi
 weight = 3
 tags = ["plugin", "auto"]
 categories = ["plugin"]
-date = "2020-09-24T18:42:39.8773989"
+date = "2025-12-11T04:36:33.87733812"
 +++
 
 ## Description
@@ -30,7 +30,8 @@ are used.
   used to extract the origin. **ORIGIN_TEMPLATE** will be used as a template for the origin. Strings
   like `{<number>}` are replaced with the respective matches in the file name, e.g. `{1}` is the
   first match, `{2}` is the second. The default is: `db\.(.*)  {1}` i.e. from a file with the
-  name `db.example.com`, the extracted origin will be `example.com`.
+  name `db.example.com`, the extracted origin will be `example.com`. **REGEXP** must not be longer
+  than 10000 characters.
 * `reload` interval to perform reloads of zones if SOA version changes and zonefiles. It specifies how often CoreDNS should scan the directory to watch for file removal and addition. Default is one minute.
   Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
   and reloads zone when serial changes.

--- a/content/plugins/forward.md
+++ b/content/plugins/forward.md
@@ -4,7 +4,7 @@ description = "*forward* facilitates proxying DNS messages to upstream resolvers
 weight = 20
 tags = ["plugin", "forward"]
 categories = ["plugin"]
-date = "2025-10-13T05:58:44.87744810"
+date = "2025-12-11T04:36:33.87733812"
 +++
 
 ## Description
@@ -48,6 +48,7 @@ forward FROM TO... {
     prefer_udp
     expire DURATION
     max_fails INTEGER
+    max_connect_attempts INTEGER
     tls CERT KEY CA
     tls_servername NAME
     policy random|round_robin|sequential
@@ -69,6 +70,9 @@ forward FROM TO... {
 * `max_fails` is the number of subsequent failed health checks that are needed before considering
   an upstream to be down. If 0, the upstream will never be marked as down (nor health checked).
   Default is 2.
+* `max_connect_attempts` caps the total number of upstream connect attempts
+  performed for a single incoming DNS request. Default value of 0 means no per-request
+  cap.
 * `expire` **DURATION**, expire (cached) connections after this time, the default is 10s.
 * `tls` **CERT** **KEY** **CA** define the TLS properties for TLS connection. From 0 to 3 arguments can be
   provided with the meaning as described below
@@ -81,11 +85,16 @@ forward FROM TO... {
     The server certificate is verified using the specified CA file
 
 * `tls_servername` **NAME** allows you to set a server name in the TLS configuration; for instance 9.9.9.9
-  needs this to be set to `dns.quad9.net`. Multiple upstreams are still allowed in this scenario,
-  but they have to use the same `tls_servername`. E.g. mixing 9.9.9.9 (QuadDNS) with 1.1.1.1
-  (Cloudflare) will not work. Using TLS forwarding but not setting `tls_servername` results in anyone
+  needs this to be set to `dns.quad9.net`. Using TLS forwarding but not setting `tls_servername` results in anyone
   being able to man-in-the-middle your connection to the DNS server you are forwarding to. Because of this,
   it is strongly recommended to set this value when using TLS forwarding.
+
+  Per destination endpoint TLS server name indication is possible in the form of `tls://9.9.9.9%dns.quad9.net`.
+  `tls_servername` must not be specified when using per destination endpoint TLS server name indication
+  as it would introduce clash between the server name indication spectifications. If destination endpoint
+  is to be reached via a port other than 853 then the port must be appended to the end of the destination
+  endpoint specifier. In case of port 10853, the above string would be: `tls://9.9.9.9%dns.quad9.net:10853`.
+
 * `policy` specifies the policy to use for selecting upstream servers. The default is `random`.
   * `random` is a policy that implements random upstream selection.
   * `round_robin` is a policy that selects hosts based on round robin ordering.
@@ -103,7 +112,7 @@ forward FROM TO... {
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
 * `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored
 * `failfast_all_unhealthy_upstreams` - determines the handling of requests when all upstream servers are unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL responses for all requests. By default, requests are sent to a random upstream.
-* `failover` - By default when a DNS lookup fails to return a DNS response (e.g. timeout), _forward_ will attempt a lookup on the next upstream server. The `failover` option will make _forward_ do the same for any response with a response code matching an `RCODE` ( e.g. `SERVFAIL`、`REFUSED`). If all upstreams have been tried, the response from the last attempt is returned.
+* `failover` - By default when a DNS lookup fails to return a DNS response (e.g. timeout), _forward_ will attempt a lookup on the next upstream server. The `failover` option will make _forward_ do the same for any response with a response code matching an `RCODE` ( e.g. `SERVFAIL`、`REFUSED`). `NOERROR` cannot be used. If all upstreams have been tried, the response from the last attempt is returned.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls_servername` for different upstreams you're out of luck.

--- a/content/plugins/geoip.md
+++ b/content/plugins/geoip.md
@@ -1,17 +1,19 @@
 +++
 title = "geoip"
-description = "*geoip* Lookup maxmind geoip2 databases using the client IP, then add associated geoip data to the context request."
+description = "*geoip* Lookup `.mmdb` ([MaxMind db file format](https://maxmind.github.io/MaxMind-DB/)) databases using the client IP, then add associated geoip data to the context request."
 weight = 21
 tags = ["plugin", "geoip"]
 categories = ["plugin"]
-date = "2023-02-07T20:00:01.877182"
+date = "2025-12-11T04:36:33.87733812"
 +++
 
 ## Description
 
-The *geoip* plugin add geo location data associated with the client IP, it allows you to configure a [geoIP2 maxmind database](https://dev.maxmind.com/geoip/docs/databases) to add the geo location data associated with the IP address.
+The *geoip* plugin allows you to enrich the data associated with Client IP addresses, e.g. geoip information like City, Country, and Network ASN. GeoIP data is commonly available in the `.mmdb` format, a database format that maps IPv4 and IPv6 addresses to data records using a binary search tree.
 
-The data is added leveraging the *metadata* plugin, values can then be retrieved using it as well, for example:
+The data is added leveraging the *metadata* plugin, values can then be retrieved using it as well.
+
+**Longitude example:**
 
 ```go
 import (
@@ -29,11 +31,47 @@ if getLongitude := metadata.ValueFunc(ctx, "geoip/longitude"); getLongitude != n
 // ...
 ```
 
+**City example:**
+
+```go
+import (
+    "github.com/coredns/coredns/plugin/metadata"
+)
+// ...
+if getCity := metadata.ValueFunc(ctx, "geoip/city/name"); getCity != nil {
+    city := getCity()
+    // Do something useful with city.
+} else {
+    // The metadata label geoip/city/name for some reason, was not set.
+}
+// ...
+```
+
+**ASN example:**
+
+```go
+import (
+    "strconv"
+    "github.com/coredns/coredns/plugin/metadata"
+)
+// ...
+if getASN := metadata.ValueFunc(ctx, "geoip/asn/number"); getASN != nil {
+    if asn, err := strconv.ParseUint(getASN(), 10, 32); err == nil {
+        // Do something useful with asn.
+    }
+}
+if getASNOrg := metadata.ValueFunc(ctx, "geoip/asn/org"); getASNOrg != nil {
+    asnOrg := getASNOrg()
+    // Do something useful with asnOrg.
+}
+// ...
+```
+
 ## Databases
 
-The supported databases use city schema such as `City` and `Enterprise`. Other databases types with different schemas are not supported yet.
+The supported databases use city schema such as `ASN`, `City`, and `Enterprise`. `.mmdb` files are generally supported, as long as their field names correctly map to the Metadata Labels below. Other database types with different schemas are not supported yet.
 
-You can download a [free and public City database](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data).
+Free and commercial GeoIP `.mmdb` files are commonly available from vendors like [MaxMind](https://dev.maxmind.com/geoip/docs/databases), [IPinfo](https://ipinfo.io/developers/database-download), and [IPtoASN](https://iptoasn.com/) which is [Public Domain-licensed](https://opendatacommons.org/licenses/pddl/1-0/).
 
 ## Syntax
 
@@ -49,7 +87,7 @@ geoip [DBFILE] {
 }
 ```
 
-* **DBFILE** the mmdb database file path. We recommend updating your mmdb database periodically for more accurate results.
+* **DBFILE** the `mmdb` database file path. We recommend updating your `mmdb` database periodically for more accurate results.
 * `edns-subnet`: Optional. Use [EDNS0 subnet](https://en.wikipedia.org/wiki/EDNS_Client_Subnet) (if present) for Geo IP instead of the source IP of the DNS request. This helps identifying the closest source IP address through intermediary DNS resolvers, and it also makes GeoIP testing easy: `dig +subnet=1.2.3.4 @dns-server.example.com www.geo-aware.com`.
 
   **NOTE:** due to security reasons, recursive DNS resolvers may mask a few bits off of the clients' IP address, which can cause inaccuracies in GeoIP resolution.
@@ -106,6 +144,9 @@ A limited set of fields will be exported as labels, all values are stored using 
 | `geoip/longitude`                    | `float64` | `0.1315`         | Base 10, max available precision.
 | `geoip/timezone`                     | `string`  | `Europe/London`  | The timezone.
 | `geoip/postalcode`                   | `string`  | `CB4`            | The postal code.
+| `geoip/subdivisions/code`            | `string`  | `ENG,TWH`        | Comma separated [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) subdivision(region) codes, e.g. first level (province), second level (state).
+| `geoip/asn/number`                   | `uint`    | `396982`         | The autonomous system number.
+| `geoip/asn/org`                      | `string`  | `GOOGLE-CLOUD-PLATFORM` | The autonomous system organization.
 
 ## Continent Codes
 
@@ -118,3 +159,7 @@ A limited set of fields will be exported as labels, all values are stored using 
 | NA    | North America  |
 | OC    | Oceania        |
 | SA    | South America  |
+
+## Notable changes
+
+- In CoreDNS v1.13.2, the `geoip` plugin was upgraded to use [`oschwald/geoip2-golang/v2`](https://github.com/oschwald/geoip2-golang/blob/main/MIGRATION.md), the Go library that reads and parses [`.mmdb`](https://maxmind.github.io/MaxMind-DB/) databases. It has a small, but possibly-breaking change, where the `Location.Latitude` and `Location.Longitude` structs changed from value types to pointers (`float64` → `*float64`). In `oschwald/geoip2-golang` v1, missing coordinates returned "0" (which is a [valid location](https://en.wikipedia.org/wiki/Null_Island)), and in v2 they now return an empty string "".

--- a/content/plugins/multisocket.md
+++ b/content/plugins/multisocket.md
@@ -4,7 +4,7 @@ description = "*multisocket* allows to start multiple servers that will listen o
 weight = 36
 tags = ["plugin", "multisocket"]
 categories = ["plugin"]
-date = "2024-11-22T08:09:54.87754811"
+date = "2025-12-11T04:36:33.87733812"
 +++
 
 ## Description
@@ -22,7 +22,7 @@ large number of CPU cores.
 multisocket [NUM_SOCKETS]
 ~~~
 
-* **NUM_SOCKETS** - the number of servers that will listen on one port. Default value is equal to GOMAXPROCS.
+* **NUM_SOCKETS** - the number of servers that will listen on one port. Default value is equal to GOMAXPROCS. Maximum value is 1024.
 
 ## Examples
 
@@ -64,6 +64,10 @@ If conducting such tests is difficult, follow these recommendations:
    - If CoreDNS consumes 8 CPUs and 64 CPUs are available, set `NUM_SOCKETS` to 8.
 
 ## Limitations
+
+The `multisocket` value used for a given listen address is taken from the first server block that binds to that address
+in the Corefile. Subsequent server blocks using the same address will not change it. Different addresses may use
+different values.
 
 The SO_REUSEPORT socket option is not available for some operating systems. It is available since Linux Kernel 3.9 and 
 not available for Windows at all.

--- a/content/plugins/nomad.md
+++ b/content/plugins/nomad.md
@@ -4,7 +4,7 @@ description = "*nomad* enables reading zone data from a Nomad cluster."
 weight = 37
 tags = ["plugin", "nomad"]
 categories = ["plugin"]
-date = "2025-10-13T05:58:44.87744810"
+date = "2025-12-11T04:36:33.87733812"
 +++
 
 ## Description
@@ -83,12 +83,15 @@ With only the plugin specified, the *nomad* plugin will default to `service.noma
 ~~~ txt
 nomad [ZONE] {
     address URL
+    filter FILTER
     token TOKEN
     ttl DURATION
 }
 ~~~
 
 * `address` The address where a Nomad agent (server) is available. **URL** defaults to `http://127.0.0.1:4646`.
+
+* `filter` allows you to filter Nomad services. **FILTER** defaults to `""`. Uses [filtering](https://developer.hashicorp.com/nomad/api-docs#filtering) syntax.
 
 * `token` The SecretID of an ACL token to use to authenticate API requests with if the Nomad cluster has ACL enabled. **TOKEN** defaults to `""`.
 

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.13.1"
+  version = "1.13.2"


### PR DESCRIPTION
Sync content with the latest CoreDNS release [v1.13.2](https://github.com/coredns/coredns/releases/tag/v1.13.2).
