### PR TITLE
chore: bump to v1.14.0

### DIFF
--- a/content/blog/coredns-1.14.0.md
+++ b/content/blog/coredns-1.14.0.md
@@ -1,0 +1,37 @@
++++
+title = "CoreDNS-1.14.0 Release"
+description = "CoreDNS-1.1.4.0 Release Notes."
+tags = ["Release", "1.14.0", "Notes"]
+release = "1.14.0"
+date = "2026-01-10T00:00:00+00:00"
+author = "coredns"
++++
+
+This release focuses on security hardening and operational reliability. Core updates
+introduce a regex length limit to reduce resource-exhaustion risk. Plugin updates
+improve error consolidation (`show_first`), reduce misleading SOA warnings, add
+Kubernetes API rate limiting, enhance metrics with plugin chain tracking, and fix
+issues in azure and sign. This release also includes additional security fixes;
+see the security advisory for details.
+
+## Brought to You By
+
+cangming
+pasteley
+Raisa Kabir
+Ross Golder
+rusttech
+Syed Azeez
+Ville Vesilehto
+Yong Tang
+
+## Noteworthy Changes
+
+* core: Fix gosec G115 integer overflow warnings (https://github.com/coredns/coredns/pull/7799)
+* core: Add regex length limit (https://github.com/coredns/coredns/pull/7802)
+* plugin/azure: Fix slice init length (https://github.com/coredns/coredns/pull/6901)
+* plugin/errors: Add optional `show_first` flag to consolidate directive (https://github.com/coredns/coredns/pull/7703)
+* plugin/file: Fix for misleading SOA parser warnings (https://github.com/coredns/coredns/pull/7774)
+* plugin/kubernetes: Rate limits to api server (https://github.com/coredns/coredns/pull/7771)
+* plugin/metrics: Implement plugin chain tracking (https://github.com/coredns/coredns/pull/7791)
+* plugin/sign: Report parser err before missing SOA (https://github.com/coredns/coredns/pull/7775)

--- a/content/plugins/clouddns.md
+++ b/content/plugins/clouddns.md
@@ -4,7 +4,7 @@ description = "*clouddns* enables serving zone data from GCP Cloud DNS."
 weight = 11
 tags = ["plugin", "clouddns"]
 categories = ["plugin"]
-date = "2022-04-06T19:05:17.8771784"
+date = "2026-01-08T11:42:04.877481"
 +++
 
 ## Description
@@ -38,8 +38,10 @@ clouddns [ZONE:PROJECT_ID:HOSTED_ZONE_NAME...] {
 
 *   `credentials` is used for reading the credential file from **FILENAME** (normally a .json file).
     This field is optional. If this field is not provided then authentication will be done automatically,
-    e.g., through environmental variable `GOOGLE_APPLICATION_CREDENTIALS`. Please see
-    Google Cloud's [authentication method](https://cloud.google.com/docs/authentication) for more details.
+    e.g., through environmental variable `GOOGLE_APPLICATION_CREDENTIALS`. Note that CoreDNS validates that the given
+    file has a valid credentials type, but does not validate the credentials file for malicious input. Please see
+    Google Cloud's [authentication method](https://cloud.google.com/docs/authentication) and
+    [validating credential configurations from external sources](https://docs.cloud.google.com/docs/authentication/client-libraries#external-credentials) for more details.
 
 *   `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
     If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin is

--- a/content/plugins/errors.md
+++ b/content/plugins/errors.md
@@ -4,7 +4,7 @@ description = "*errors* enables error logging."
 weight = 17
 tags = ["plugin", "errors"]
 categories = ["plugin"]
-date = "2022-06-09T07:57:48.8774886"
+date = "2026-01-08T11:42:04.877481"
 +++
 
 ## Description
@@ -26,16 +26,31 @@ Extra knobs are available with an expanded syntax:
 ~~~
 errors {
 	stacktrace
-	consolidate DURATION REGEXP [LEVEL]
+	consolidate DURATION REGEXP [LEVEL] [show_first]
 }
 ~~~
 
 Option `stacktrace` will log a stacktrace during panic recovery.
 
-Option `consolidate` allows collecting several error messages matching the regular expression **REGEXP** during **DURATION**. After the **DURATION** since receiving the first such message, the consolidated message will be printed to standard output with
+Option `consolidate` allows collecting several error messages matching the regular expression **REGEXP** during **DURATION**. **REGEXP** must not exceed 10000 characters. After the **DURATION** since receiving the first such message, the consolidated message will be printed to standard output with
 log level, which is configurable by optional option **LEVEL**. Supported options for **LEVEL** option are `warning`,`error`,`info` and `debug`.
 ~~~
 2 errors like '^read udp .* i/o timeout$' occurred in last 30s
+~~~
+
+If the optional `show_first` flag is specified, the first error will be logged immediately when it occurs, and then subsequent matching errors will be consolidated. When the consolidation period ends:
+- If only one error occurred, no summary is printed (since it was already logged)
+- If multiple errors occurred, a summary is printed showing the total count
+
+Example with 3 errors:
+~~~
+[WARNING] 2 example.org. A: read udp 10.0.0.1:53->8.8.8.8:53: i/o timeout
+[WARNING] 3 errors like '^read udp .* i/o timeout$' occurred in last 30s
+~~~
+
+Example with 1 error:
+~~~
+[WARNING] 2 example.org. A: read udp 10.0.0.1:53->8.8.8.8:53: i/o timeout
 ~~~
 
 Multiple `consolidate` options with different **DURATION** and **REGEXP** are allowed. In case if some error message corresponds to several defined regular expressions the message will be associated with the first appropriate **REGEXP**.
@@ -63,6 +78,19 @@ and errors with prefix "Failed to " as errors.
     errors {
         consolidate 5m ".* i/o timeout$" warning
         consolidate 30s "^Failed to .+"
+    }
+}
+~~~
+
+Use the *forward* plugin and consolidate timeout errors with `show_first` option to see both
+the summary and the first occurrence of the error:
+
+~~~ corefile
+. {
+    forward . 8.8.8.8
+    errors {
+        consolidate 5m ".* i/o timeout$" warning show_first
+        consolidate 30s "^Failed to .+" error show_first
     }
 }
 ~~~

--- a/content/plugins/grpc_server.md
+++ b/content/plugins/grpc_server.md
@@ -1,0 +1,54 @@
++++
+title = "grpc_server"
+description = "*grpc_server* configures DNS-over-gRPC server options."
+weight = 23
+tags = ["plugin", "grpc_server"]
+categories = ["plugin"]
+date = "2026-01-08T11:42:04.877481"
++++
+
+## Description
+
+The *grpc_server* plugin allows you to configure parameters for the DNS-over-gRPC server to fine-tune the security posture and performance of the server.
+
+This plugin can only be used once per gRPC listener block.
+
+## Syntax
+
+```txt
+grpc_server {
+    max_streams POSITIVE_INTEGER
+    max_connections POSITIVE_INTEGER
+}
+```
+
+* `max_streams` limits the number of concurrent gRPC streams per connection. This helps prevent unbounded streams on a single connection, exhausting server resources. The default value is 256 if not specified. Set to 0 for unbounded.
+* `max_connections` limits the number of concurrent TCP connections to the gRPC server. The default value is 200 if not specified. Set to 0 for unbounded.
+
+## Examples
+
+Set custom limits for maximum streams and connections:
+
+```
+grpc://.:8053 {
+    tls cert.pem key.pem
+    grpc_server {
+        max_streams 50
+        max_connections 100
+    }
+    whoami
+}
+```
+
+Set values to 0 for unbounded, matching CoreDNS behaviour before v1.14.0:
+
+```
+grpc://.:8053 {
+    tls cert.pem key.pem
+    grpc_server {
+        max_streams 0
+        max_connections 0
+    }
+    whoami
+}
+```

--- a/content/plugins/https.md
+++ b/content/plugins/https.md
@@ -1,0 +1,50 @@
++++
+title = "https"
+description = "*https* configures DNS-over-HTTPS (DoH) server options."
+weight = 27
+tags = ["plugin", "https"]
+categories = ["plugin"]
+date = "2026-01-08T11:42:04.877481"
++++
+
+## Description
+
+The *https* plugin allows you to configure parameters for the DNS-over-HTTPS (DoH) server to fine-tune the security posture and performance of the server.
+
+This plugin can only be used once per HTTPS listener block.
+
+## Syntax
+
+```txt
+https {
+    max_connections POSITIVE_INTEGER
+}
+```
+
+* `max_connections` limits the number of concurrent TCP connections to the HTTPS server. The default value is 200 if not specified. Set to 0 for unbounded.
+
+## Examples
+
+Set custom limits for maximum connections:
+
+```
+https://.:443 {
+    tls cert.pem key.pem
+    https {
+        max_connections 100
+    }
+    whoami
+}
+```
+
+Set values to 0 for unbounded, matching CoreDNS behaviour before v1.14.0:
+
+```
+https://.:443 {
+    tls cert.pem key.pem
+    https {
+        max_connections 0
+    }
+    whoami
+}
+```

--- a/content/plugins/https3.md
+++ b/content/plugins/https3.md
@@ -1,0 +1,50 @@
++++
+title = "https3"
+description = "*https3* configures DNS-over-HTTPS/3 (DoH3) server options."
+weight = 28
+tags = ["plugin", "https3"]
+categories = ["plugin"]
+date = "2026-01-08T11:42:04.877481"
++++
+
+## Description
+
+The *https3* plugin allows you to configure parameters for the DNS-over-HTTPS/3 (DoH3) server to fine-tune the security posture and performance of the server. HTTPS/3 uses QUIC as the underlying transport.
+
+This plugin can only be used once per HTTPS3 listener block.
+
+## Syntax
+
+```txt
+https3 {
+    max_streams POSITIVE_INTEGER
+}
+```
+
+* `max_streams` limits the number of concurrent QUIC streams per connection. This helps prevent unbounded streams on a single connection, exhausting server resources. The default value is 256 if not specified. Set to 0 to use underlying QUIC transport default.
+
+## Examples
+
+Set custom limits for maximum streams:
+
+```
+https3://.:443 {
+    tls cert.pem key.pem
+    https3 {
+        max_streams 50
+    }
+    whoami
+}
+```
+
+Set values to 0 for QUIC transport default, matching CoreDNS behaviour before v1.14.0:
+
+```
+https3://.:443 {
+    tls cert.pem key.pem
+    https3 {
+        max_streams 0
+    }
+    whoami
+}
+```

--- a/content/plugins/kubernetes.md
+++ b/content/plugins/kubernetes.md
@@ -1,10 +1,10 @@
 +++
 title = "kubernetes"
 description = "*kubernetes* enables reading zone data from a Kubernetes cluster."
-weight = 28
+weight = 31
 tags = ["plugin", "kubernetes"]
 categories = ["plugin"]
-date = "2025-09-09T19:02:11.8771189"
+date = "2026-01-08T11:42:04.877481"
 +++
 
 ## Description
@@ -37,6 +37,9 @@ kubernetes [ZONES...] {
     endpoint URL
     tls CERT KEY CACERT
     kubeconfig KUBECONFIG [CONTEXT]
+    apiserver_qps QPS
+    apiserver_burst BURST
+    apiserver_max_inflight MAX
     namespaces NAMESPACE...
     labels EXPRESSION
     pods POD-MODE
@@ -58,6 +61,12 @@ kubernetes [ZONES...] {
    **[CONTEXT]** is optional, if not set, then the current context specified in kubeconfig will be used.
    It supports TLS, username and password, or token-based authentication.
    This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
+* `apiserver_qps` **QPS** sets the maximum queries per second (QPS) rate limit for requests.
+   This allows you to control the rate at which the plugin sends requests to the API server to prevent overwhelming it.
+* `apiserver_burst` **BURST** sets the maximum burst size for requests.
+   This allows temporary spikes in request rate up to this value, even if it exceeds the QPS limit.
+* `apiserver_max_inflight` **MAX** sets the maximum number of concurrent in-flight requests.
+   This caps the total number of simultaneous requests the plugin can make to the API server.
 * `namespaces` **NAMESPACE [NAMESPACE...]** only exposes the k8s namespaces listed.
    If this option is omitted all namespaces are exposed
 * `namespace_labels` **EXPRESSION** only expose the records for Kubernetes namespaces that match this label selector.

--- a/content/plugins/rewrite.md
+++ b/content/plugins/rewrite.md
@@ -1,10 +1,10 @@
 +++
 title = "rewrite"
 description = "*rewrite* performs internal message rewriting."
-weight = 42
+weight = 46
 tags = ["plugin", "rewrite"]
 categories = ["plugin"]
-date = "2025-09-09T19:01:00.877089"
+date = "2026-01-08T11:42:04.877481"
 +++
 
 ## Description
@@ -77,7 +77,8 @@ The match type, e.g., `exact`, `substring`, etc., triggers rewrite:
 * **substring**: on a partial match of the name in the question section of a request
 * **prefix**: when the name begins with the matching string
 * **suffix**: when the name ends with the matching string
-* **regex**: when the name in the question section of a request matches a regular expression
+* **regex**: when the name in the question section of a request matches a regular expression.
+  Regex patterns must not exceed 10000 characters.
 
 If the match type is omitted, the `exact` match type is assumed. If OPTIONS are
 given, the type must be specified.

--- a/content/plugins/template.md
+++ b/content/plugins/template.md
@@ -1,10 +1,10 @@
 +++
 title = "template"
 description = "*template* allows for dynamic responses based on the incoming query."
-weight = 45
+weight = 51
 tags = ["plugin", "template"]
 categories = ["plugin"]
-date = "2023-02-07T20:00:01.877182"
+date = "2026-01-08T11:42:04.877481"
 +++
 
 ## Description
@@ -29,7 +29,8 @@ template CLASS TYPE [ZONE...] {
 * **TYPE** the query type (A, PTR, ... can be ANY to match all types).
 * **ZONE** the zone scope(s) for this template. Defaults to the server zones.
 * `match` **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name.
-  Specifying no regex matches everything (default: `.*`). First matching regex wins.
+  Specifying no regex matches everything (default: `.*`). First matching regex wins. Regex patterns
+  must not exceed 10000 characters.
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
   built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply. Specifying no answer will result
   in a response with an empty answer section.

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.13.2"
+  version = "1.14.0"


### PR DESCRIPTION
Generate docs from [v1.14.0](https://github.com/coredns/coredns/releases/tag/v1.14.0).

cc @yongtang 