### PR TITLE
chore: bump to v1.14.1

### DIFF
--- a/content/blog/coredns-1.14.1.md
+++ b/content/blog/coredns-1.14.1.md
@@ -1,0 +1,24 @@
++++
+title = "CoreDNS-1.14. Release"
+description = "CoreDNS-1.14.1 Release Notes."
+tags = ["Release", "1.14.1", "Notes"]
+release = "1.14.1"
+date = "2026-01-15T00:00:00+00:00"
+author = "coredns"
++++
+
+This release primarily addresses security vulnerabilities affecting Go versions prior to
+Go 1.25.6 and Go 1.24.12 (CVE-2025-61728, CVE-2025-61726, CVE-2025-68121, CVE-2025-61731,
+CVE-2025-68119). It also includes performance improvements to the proxy plugin via
+multiplexed connections, along with various documentation updates.
+
+## Brought to You By
+
+Alex Massy
+Shiv Tyagi
+Ville Vesilehto
+Yong Tang
+
+## Noteworthy Changes
+
+* plugin/proxy: Use mutex-based connection pool (https://github.com/coredns/coredns/pull/7790)

--- a/content/plugins/forward.md
+++ b/content/plugins/forward.md
@@ -4,7 +4,7 @@ description = "*forward* facilitates proxying DNS messages to upstream resolvers
 weight = 20
 tags = ["plugin", "forward"]
 categories = ["plugin"]
-date = "2025-12-11T04:36:33.87733812"
+date = "2026-01-17T06:17:00.877081"
 +++
 
 ## Description
@@ -47,6 +47,7 @@ forward FROM TO... {
     force_tcp
     prefer_udp
     expire DURATION
+    max_idle_conns INTEGER
     max_fails INTEGER
     max_connect_attempts INTEGER
     tls CERT KEY CA
@@ -74,6 +75,8 @@ forward FROM TO... {
   performed for a single incoming DNS request. Default value of 0 means no per-request
   cap.
 * `expire` **DURATION**, expire (cached) connections after this time, the default is 10s.
+* `max_idle_conns` **INTEGER**, maximum number of idle connections to cache per upstream for reuse.
+  Default is 0, which means unlimited.
 * `tls` **CERT** **KEY** **CA** define the TLS properties for TLS connection. From 0 to 3 arguments can be
   provided with the meaning as described below
 

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.14.0"
+  version = "1.14.1"


### PR DESCRIPTION
Generate docs from [v1.14.1](https://github.com/coredns/coredns/releases/tag/v1.14.1).

cc @yongtang 