### PR TITLE
chore: bump to v1.14.2

### DIFF
--- a/content/blog/coredns-1.14.1.md
+++ b/content/blog/coredns-1.14.1.md
@@ -1,5 +1,5 @@
 +++
-title = "CoreDNS-1.14. Release"
+title = "CoreDNS-1.14.1 Release"
 description = "CoreDNS-1.14.1 Release Notes."
 tags = ["Release", "1.14.1", "Notes"]
 release = "1.14.1"

--- a/content/blog/coredns-1.14.2.md
+++ b/content/blog/coredns-1.14.2.md
@@ -1,0 +1,42 @@
++++
+title = "CoreDNS-1.14.2 Release"
+description = "CoreDNS-1.14.2 Release Notes."
+tags = ["Release", "1.14.2", "Notes"]
+release = "1.14.2"
+date = "2026-03-15T00:00:00+00:00"
+author = "coredns"
++++
+
+This release adds the new proxyproto plugin to support Proxy Protocol and preserve
+client IPs behind load balancers. It also includes enhancements such as improved DNS
+logging metadata and stronger randomness for loop detection (CVE-2026-26018), along
+with several bug fixes including TLS+IPv6 forwarding, improved CNAME handling and
+rewriting, allowing jitter disabling, prevention of an ACL bypass (CVE-2026-26017),
+and a Kubernetes plugin crash fix. In addition, the release updates the build to
+Go 1.26.1, which include security fixes addressing CVE-2026-27137, CVE-2026-27138, CVE-2026-27139,
+CVE-2026-25679, and CVE-2026-27142.
+
+## Brought to You By
+
+Adphi
+Henrik Gerdes
+hide
+Kelly Kane
+Shiv Tyagi
+vflaux
+Ville Vesilehto
+yangsenzk
+Yong Tang
+YOUNEVSKY
+
+## Noteworthy Changes
+
+* core: Reorder rewrite before acl to prevent bypass (https://github.com/coredns/coredns/pull/7882)
+* plugin/file: Return SOA and NS records when queried for a record CNAMEd to origin (https://github.com/coredns/coredns/pull/7808)
+* plugin/forward: Fix parsing error when handling TLS+IPv6 address (https://github.com/coredns/coredns/pull/7848)
+* plugin/log: Add metadata for response Type and Class to Log (https://github.com/coredns/coredns/pull/7806)
+* plugin/loop: Use crypto/rand for query name generation (https://github.com/coredns/coredns/pull/7881)
+* plugin/kubernetes: Fix panic on empty ListenHosts (https://github.com/coredns/coredns/pull/7857)
+* plugin/proxyproto: Add proxy protocol support (https://github.com/coredns/coredns/pull/7738)
+* plugin/reload: Allow disabling jitter with 0s (https://github.com/coredns/coredns/pull/7896)
+* plugin/rewrite: Fix cname target rewrite for CNAME chains (https://github.com/coredns/coredns/pull/7853)

--- a/content/plugins/kubernetes.md
+++ b/content/plugins/kubernetes.md
@@ -4,7 +4,7 @@ description = "*kubernetes* enables reading zone data from a Kubernetes cluster.
 weight = 31
 tags = ["plugin", "kubernetes"]
 categories = ["plugin"]
-date = "2026-01-08T11:42:04.877481"
+date = "2026-03-06T16:27:00.877083"
 +++
 
 ## Description
@@ -54,13 +54,14 @@ kubernetes [ZONES...] {
 ```
 
 * `endpoint` specifies the **URL** for a remote k8s API endpoint.
-   If omitted, it will connect to k8s in-cluster using the cluster service account.
+   If omitted, it will connect to k8s in-cluster using the cluster service account. Needs `tls` for clusters with authentication.
+   This option is ignored if `kubeconfig` is set.
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
    This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
 * `kubeconfig` **KUBECONFIG [CONTEXT]** authenticates the connection to a remote k8s cluster using a kubeconfig file.
    **[CONTEXT]** is optional, if not set, then the current context specified in kubeconfig will be used.
    It supports TLS, username and password, or token-based authentication.
-   This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
+   This option is ignored if omitted. The cluster address in the `kubeconfig` is given preference.
 * `apiserver_qps` **QPS** sets the maximum queries per second (QPS) rate limit for requests.
    This allows you to control the rate at which the plugin sends requests to the API server to prevent overwhelming it.
 * `apiserver_burst` **BURST** sets the maximum burst size for requests.

--- a/content/plugins/log.md
+++ b/content/plugins/log.md
@@ -1,10 +1,10 @@
 +++
 title = "log"
 description = "*log* enables query logging to standard output."
-weight = 31
+weight = 34
 tags = ["plugin", "log"]
 categories = ["plugin"]
-date = "2021-09-21T15:01:04.877489"
+date = "2026-03-06T16:27:00.877083"
 +++
 
 ## Description
@@ -95,6 +95,19 @@ Each of these logs will be outputted with `log.Infof`, so a typical example look
 
 ~~~ txt
 [INFO] [::1]:50759 - 29008 "A IN example.org. udp 41 false 4096" NOERROR qr,rd,ra,ad 68 0.037990251s
+~~~
+
+## Additional metadata
+
+The log plugin adds the following metadata to allow for granular differentiation of NOERROR denial vs success messages. These are mapped from `plugin/pkg/response/classify.go` and `plugin/pkg/response/typify.go`.
+
+* `{/log/class}`: success, denial
+* `{/log/type}`: NODATA, NXDOMAIN, NOERROR
+
+~~~ corefile
+. {
+    log . "{proto} Request: {name} {type} {/log/class} {/log/type}"
+}
 ~~~
 
 ## Examples

--- a/content/plugins/proxyproto.md
+++ b/content/plugins/proxyproto.md
@@ -1,0 +1,66 @@
++++
+title = "proxyproto"
+description = "*proxyproto* add [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) support."
+weight = 43
+tags = ["plugin", "proxyproto"]
+categories = ["plugin"]
+date = "2026-03-06T16:27:00.877083"
++++
+
+## Description
+
+This plugin adds support for the PROXY protocol version 1 and 2. It allows CoreDNS to receive
+connections from a load balancer or proxy that uses the PROXY protocol to forward the original
+client's IP address and port information.
+
+## Syntax
+
+~~~ txt
+proxyproto {
+    allow <CIDR...>
+    default <use|ignore|reject|skip>
+}
+~~~
+
+If `allow` is unspecified, PROXY protocol headers are accepted from all IP addresses.
+The `default` option controls how connections from sources not listed in `allow` are handled.
+If `default` is unspecified, it defaults to `ignore`.
+The possible values are:
+- `use`: accept and use PROXY protocol headers from these sources
+- `ignore`: accept and ignore PROXY protocol headers from other sources
+- `reject`: reject connections with PROXY protocol headers from other sources
+- `skip`: skip PROXY protocol processing for connections from other sources, treating them as normal connections preserving the PROXY protocol headers.
+
+
+## Examples
+
+In this configuration, we allow PROXY protocol connections from all IP addresses:
+~~~ corefile
+. {
+    proxyproto
+    forward . /etc/resolv.conf
+}
+~~~
+
+In this configuration, we only allow PROXY protocol connections from the specified CIDR ranges
+and ignore proxy protocol headers from other sources:
+~~~ corefile
+. {
+    proxyproto {
+        allow 192.168.1.1/32 192.168.0.1/32
+    }
+    forward . /etc/resolv.conf
+}
+~~~
+
+In this configuration, we only allow PROXY protocol headers from the specified CIDR ranges and reject
+connections without valid PROXY protocol headers from those sources:
+~~~ corefile
+. {
+    proxyproto {
+        allow 192.168.1.1/32
+        default reject
+    }
+    forward . /etc/resolv.conf
+}
+~~~

--- a/content/plugins/rewrite.md
+++ b/content/plugins/rewrite.md
@@ -1,10 +1,10 @@
 +++
 title = "rewrite"
 description = "*rewrite* performs internal message rewriting."
-weight = 46
+weight = 47
 tags = ["plugin", "rewrite"]
 categories = ["plugin"]
-date = "2026-01-08T11:42:04.877481"
+date = "2026-03-06T16:27:00.877083"
 +++
 
 ## Description
@@ -506,9 +506,9 @@ If only some calls contain the `revert` flag, then the value in the response wil
 
 ## CNAME Field Rewrites
 
-There might be a scenario where you want the `CNAME` target of the response to be rewritten. You can do this by using the `CNAME` field rewrite. This will generate new answer records according to the new `CNAME` target.
+There might be a scenario where you want the `CNAME` target of the response to be rewritten. You can do this by using the `CNAME` field rewrite. Answer records preceding the `CNAME` target are kept unchanged, the `CNAME` target is rewritten, and the subsequent records are replaced with the lookup result of the rewritten `CNAME` target.
 
-The syntax for the CNAME rewrite rule is as follows. The meaning of
+The syntax for the `CNAME` rewrite rule is as follows. The meaning of
 `exact|prefix|suffix|substring|regex` is the same as with the name rewrite rules.
 An omitted type is defaulted to `exact`.
 
@@ -530,7 +530,8 @@ $ dig @10.1.1.1 my-app.com
 ;my-app.com. IN A
 
 ;; ANSWER SECTION:
-my-app.com.                  200  IN  CNAME  my-app.com.cdn.example.net.
+my-app.com.                  200  IN  CNAME  my-app.example.
+my-app.example.              200  IN  CNAME  my-app.com.cdn.example.net.
 my-app.com.cdn.example.net.  300  IN  A      20.2.0.1
 my-app.com.cdn.example.net.  300  IN  A      20.2.0.2
 ```
@@ -544,7 +545,9 @@ $ dig @10.1.1.1 my-app.com
 ;my-app.com. IN A
 
 ;; ANSWER SECTION:
-my-app.com.                  200  IN  CNAME  my-app.com.other.cdn.com.
+my-app.com.                  200  IN  CNAME  my-app.example.
+my-app.example.              200  IN  CNAME  my-app.com.other.cdn.com.
 my-app.com.other.cdn.com.    100  IN  A      30.3.1.2
 ```
+
 Note that the answer will contain a completely different set of answer records after rewriting the `CNAME` target.

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.14.1"
+  version = "1.14.2"


### PR DESCRIPTION
Generate docs from [v1.14.2](https://github.com/coredns/coredns/releases/tag/v1.14.2).

cc @yongtang 