### PR TITLE
fix: netlify build

### DIFF
--- a/content/blog/coredns-1.14.2.md
+++ b/content/blog/coredns-1.14.2.md
@@ -3,7 +3,7 @@ title = "CoreDNS-1.14.2 Release"
 description = "CoreDNS-1.14.2 Release Notes."
 tags = ["Release", "1.14.2", "Notes"]
 release = "1.14.2"
-date = "2026-03-15T00:00:00+00:00"
+date = "2026-03-06T00:00:00+00:00"
 author = "coredns"
 +++
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,9 @@
 [build]
   publish = "public"
-  command = "hugo"
+  command = "make"
 
-[context.production.environment]
+[build.environment]
   HUGO_VERSION = "0.100.2"
-  HUGO_ENV = "make"
 
 [context.deploy-preview]
   command = "make"


### PR DESCRIPTION
After merging #342 the Netlify build failed: https://app.netlify.com/projects/coredns/deploys/69ab00f18e213e000805c1d0

```
6:30:18 PM: Build command from Netlify app                                
6:30:18 PM: ────────────────────────────────────────────────────────────────
6:30:18 PM: ​
6:30:18 PM: $ make
6:30:18 PM: hugo -d public/
6:30:18 PM: make: hugo: No such file or directory
6:30:18 PM: make: *** [Makefile:4: all] Error 127
6:30:18 PM: ​
6:30:18 PM: "build.command" failed      
```

Netlify's new [noble-new-builds image](https://answers.netlify.com/t/new-ubuntu-24-04-noble-numbat-build-image/130497) requires `HUGO_VERSION` under `[build.environment]` to install Hugo. The old `.netlify.toml` placed it under `[context.production.environment]`, which the new image no longer picks up during the install phase.

I incorporated the change from https://github.com/coredns/coredns/pull/7906 here already even though it's not merged in. If it's missing, then Netlify will not render the latest doc page at all (because it's in the future).