### PR TITLE
fix: restore Hugo build compatibility

### DIFF
--- a/themes/coredns/layouts/_default/baseof.html
+++ b/themes/coredns/layouts/_default/baseof.html
@@ -24,7 +24,7 @@
   <!-- Site verification -->
   {{ if .IsHome }} {{ partial "site-verification" . }} {{ end }}
   <!-- add googleAnalytics in config.toml -->
-  {{ template "_internal/google_analytics_async.html" . }}
+  {{ template "_internal/google_analytics.html" . }}
   {{ with .OutputFormats.Get "rss" -}}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
   {{ end -}}

--- a/themes/coredns/layouts/blog/single.html
+++ b/themes/coredns/layouts/blog/single.html
@@ -29,11 +29,7 @@
         {{ partial "post/related-content" . }}
     </div>
 
-    {{ if .Site.DisqusShortname }}
-    <article>
-        {{ template "_internal/disqus.html" . }}
-    </article>
-    {{ end }}
+    {{ template "_internal/disqus.html" . }}
 
     {{ partial "notes-source" . }}
 

--- a/themes/coredns/layouts/community/list.html
+++ b/themes/coredns/layouts/community/list.html
@@ -17,11 +17,7 @@
 
 </div>
 
-    {{ if .Site.DisqusShortname }}
-    <article>
-        {{ template "_internal/disqus.html" . }}
-    </article>
-    {{ end }}
+    {{ template "_internal/disqus.html" . }}
     
 </div>
 </div>


### PR DESCRIPTION
Fixes #311

`make` blows up on current Hugo because `_internal/google_analytics_async.html` is gone. After that, `.Site.DisqusShortname` is another tripwire.

This switches to `_internal/google_analytics.html` and lets the embedded Disqus template decide if it should render. Small fix, no config churn, pretty low risk.

Repro:
1. Install Hugo 0.134.1 or newer
2. Run `make`
3. See `no such template "_internal/google_analytics_async.html"`

Checked:
1. `make all` with Hugo 0.161.0
2. Site build with Hugo 0.100.2 from `netlify.toml`
