### PR TITLE
chore: bump to v1.14.4

### DIFF
--- a/content/blog/coredns-1.14.3.md
+++ b/content/blog/coredns-1.14.3.md
@@ -1,0 +1,78 @@
++++
+title = "CoreDNS-1.14.3 Release"
+description = "CoreDNS-1.14.3 Release Notes."
+tags = ["Release", "1.14.3", "Notes"]
+release = "1.14.3"
+date = "2026-03-06T00:00:00+00:00"
+author = "coredns"
++++
+
+This release introduces Windows service support, along with full TSIG verification
+across DoH, DoH3, QUIC, and gRPC transports, and improved TSIG propagation and DoH
+request validation. It also adds optional TLS for the metrics endpoint. Performance
+and stability are improved through cache prefetching, QUIC optimizations, and a new
+max_age option in the forward plugin. Additional updates include enhanced SVCB/HTTPS
+support, improved zone transfer behavior, and various DNSSEC, PROXY protocol, and
+concurrency fixes. The release is built with Go 1.26.2, which includes security
+fixes addressing CVE-2026-32282, CVE-2026-32289, CVE-2026-33810, CVE-2026-27144,
+CVE-2026-27143, CVE-2026-32288, CVE-2026-32283, and CVE-2026-27140, and also includes
+fixes for CVE-2026-32936, CVE-2026-33190, CVE-2026-33489, CVE-2026-32934, and CVE-2026-35579.
+
+## Brought to You By
+
+andreyrusanov-ec
+cangming
+Cedric Wang
+Ilya Kulakov
+Ingmar Van Glabbeek
+John-Michael Mulesa
+JUN YANG
+liucongran
+Minghang Chen
+Peppi-Lotta
+rpb-ant
+Seena Fallah
+Syed Azeez
+Umut Polat
+Ville Vesilehto
+Yong Tang
+
+## Noteworthy Changes
+
+* core: Add full TSIG verification in DoH transport (https://github.com/coredns/coredns/pull/8013)
+* core: Add full TSIG verification in DoH3 transport (https://github.com/coredns/coredns/pull/8044)
+* core: Add full TSIG verification in QUIC transport (ttps://github.com/coredns/coredns/pull/8007)
+* core: Add full TSIG verification in gRPC transport (https://github.com/coredns/coredns/pull/8006)
+* core: Add support for running CoreDNS as a Windows service (https://github.com/coredns/coredns/pull/7962)
+* core: Avoid spawning waiter goroutines when QUIC worker pool is full (https://github.com/coredns/coredns/pull/7927)
+* core: Preserve TSIG status in gRPC transport (https://github.com/coredns/coredns/pull/7943)
+* core: Propagate TSIG secrets to DoT server (https://github.com/coredns/coredns/pull/7928)
+* core: Propagate TSIG status in DoQ transport (https://github.com/coredns/coredns/pull/7947)
+* core: Reject oversized GET dns query parameter of DoH (https://github.com/coredns/coredns/pull/7926)
+* core: Use per-connection local address for PROXY protocol (https://github.com/coredns/coredns/pull/8005)
+* plugin/auto: Resolve symlinked directory before walk (https://github.com/coredns/coredns/pull/8032)
+* plugin/cache: Add an atomic.Bool to singleflight prefetching (https://github.com/coredns/coredns/pull/7963)
+* plugin/cache: Prefetch without holding a client connection (https://github.com/coredns/coredns/pull/7944)
+* plugin/dnssec: Add defensive nil checks (https://github.com/coredns/coredns/pull/7997)
+* plugin/dnssec: Avoid caching empty signing results (https://github.com/coredns/coredns/pull/7996)
+* plugin/dnssec: Return nil from ParseKeyFile on error (https://github.com/coredns/coredns/pull/8000)
+* plugin/dnssec: Return nil sigs on sign error (https://github.com/coredns/coredns/pull/7999)
+* plugin/dnsserver: Allow view server blocks in any declaration order (https://github.com/coredns/coredns/pull/8001)
+* plugin/file: Expand SVCB/HTTPS record support (https://github.com/coredns/coredns/pull/7950)
+* plugin/file: Fix data race in xfr.go (https://github.com/coredns/coredns/pull/8039)
+* plugin/file: Introduce snapshot()/setData() accessors for zone data (https://github.com/coredns/coredns/pull/8040)
+* plugin/file: Protect Zone.Expired with mutex (https://github.com/coredns/coredns/pull/7940)
+* plugin/forward: Add max_age option to enforce an absolute connection lifetime (https://github.com/coredns/coredns/pull/7903)
+* plugin/kubernetes: Record cluster_ip services in dns_programming_duration metric (https://github.com/coredns/coredns/pull/7951)
+* plugin/kubernetes: Sanitize non-UTF-8 host in metrics (https://github.com/coredns/coredns/pull/7998)
+* plugin/metrics: Add optional TLS support to /metrics endpoint (https://github.com/coredns/coredns/pull/7255)
+* plugin/metrics: Allow selectively exporting all Go runtime metrics (https://github.com/coredns/coredns/pull/7990)
+* plugin/ready: fix Reset list of readiness plugins (https://github.com/coredns/coredns/pull/8035)
+* plugin/secondary: Send NOTIFY messages after zone transfer (https://github.com/coredns/coredns/pull/7901)
+* plugin/tls: Add the keylog option to configure TLSConfig.KeyLogWriter (https://github.com/coredns/coredns/pull/7537)
+* plugin/tls: Use temp dir for keylog test path (https://github.com/coredns/coredns/pull/8010)
+* plugin/transfer: Batch AXFR records by message size instead of count (https://github.com/coredns/coredns/pull/8002)
+* plugin/transfer: Fix case-sensitive zone handling for AXFR/IXFR (https://github.com/coredns/coredns/pull/7899)
+* plugin/transfter: Fix longestMatch to select the most specific zone correctly (https://github.com/coredns/coredns/pull/7949)
+* plugin/tsig: Add require_opcode directive for opcode-based TSIG (https://github.com/coredns/coredns/pull/7828)
+* proxyproto: Add UDP session tracking for Cloudflare Spectrum PPv2 (https://github.com/coredns/coredns/pull/7967)

--- a/content/blog/coredns-1.14.4.md
+++ b/content/blog/coredns-1.14.4.md
@@ -1,0 +1,60 @@
++++
+title = "CoreDNS-1.14.4 Release"
+description = "CoreDNS-1.14.4 Release Notes."
+tags = ["Release", "1.14.4", "Notes"]
+release = "1.14.4"
+date = "2026-06-09T00:00:00+00:00"
+author = "coredns"
++++
+
+This release improves transport security and operational flexibility, with
+enhancements for DoH3 and DoQ, improved DNSSEC signing behavior, and support for
+the loong64 architecture. It also adds configurable cache verification, hostname
+resolution for forward targets, incoming connection support for dnstap, fallthrough
+support in the secondary plugin, automatic zone reloads, and improved forwarding
+behavior for NODATA responses.
+
+## Brought to You By
+
+Cedric Wang
+Charlie Tonneslan
+Dmytro Alieksieiev
+Endre Szabo
+Immanuel Tikhonov
+Isolus
+James R T
+JUN YANG
+Jöran Malek
+Nicholas Amorim
+Syed Azeez
+Umut Polat
+Ville Vesilehto
+weiguozhang
+Yong Tang
+徐晓伟
+
+## Noteworthy Changes
+
+* core: Add loong64 arch support (https://github.com/coredns/coredns/pull/8137)
+* core: Bound HTTP/3 request header size for DoH3 (https://github.com/coredns/coredns/pull/8135)
+* core: Expose TLS ConnectionState (SNI) for DoQ (https://github.com/coredns/coredns/pull/8129)
+* core: Remove duplicate cipher suites (https://github.com/coredns/coredns/pull/8118)
+* core: Use http.LocalAddrContextKey for DoH local address (https://github.com/coredns/coredns/pull/8149)
+* plgin/kubernetes: Remove debug fmt.Println from multicluster zone validation (https://github.com/coredns/coredns/pull/8131)
+* plugin/any: Reject invalid any and local config (https://github.com/coredns/coredns/pull/8133)
+* plugin/azure: Apply `access` mode to every zone in the same block (https://github.com/coredns/coredns/pull/8110)
+* plugin/cache: Add optional verify timeout to serve_stale (https://github.com/coredns/coredns/pull/8070)
+* plugin/cache: Allow cache TTLs above default 3600s (https://github.com/coredns/coredns/pull/8134)
+* plugin/cache: Prefer positive cache over SERVFAIL in ncache (https://github.com/coredns/coredns/pull/8003)
+* plugin/chaos: Reject unknown chaos block options (https://github.com/coredns/coredns/pull/8121)
+* plugin/dnssec: Sign each RRset with the zone that owns its name, not the query zone (https://github.com/coredns/coredns/pull/8138)
+* plugin/dnstap: Feature: Added incoming connection support (https://github.com/coredns/coredns/pull/8086)
+* plugin/file: Canonicalize escape form in owner names (https://github.com/coredns/coredns/pull/8109)
+* plugin/file: Trigger reload of zones based on mtime (https://github.com/coredns/coredns/pull/8085)
+* plugin/forward: Add hostname resolution support for TO endpoints (https://github.com/coredns/coredns/pull/5646) (https://github.com/coredns/coredns/pull/7923)
+* plugin/forward: Forward NODATA responses to Next handler (https://github.com/coredns/coredns/pull/8065)
+* plugin/health: Use descriptive error for unknown block options in health and log plugins (https://github.com/coredns/coredns/pull/8128)
+* plugin/ready: Reject unknown ready plugin properties (https://github.com/coredns/coredns/pull/8119)
+* plugin/proxyproto: Prevent nil pointer dereference when dropping malformed PROXY packets (https://github.com/coredns/coredns/pull/8154)
+* plugin/secondary: Add fallthrough support (https://github.com/coredns/coredns/pull/8041)
+* plugin/trace: Reject unknown trace and dnstap block options (https://github.com/coredns/coredns/pull/8120)

--- a/content/plugins/cache.md
+++ b/content/plugins/cache.md
@@ -4,7 +4,7 @@ description = "*cache* enables a frontend cache."
 weight = 8
 tags = ["plugin", "cache"]
 categories = ["plugin"]
-date = "2023-02-07T20:00:01.877182"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -29,6 +29,10 @@ cache [TTL] [ZONES...]
 * **ZONES** zones it should cache for. If empty, the zones from the configuration block are used.
 
 Each element in the cache is cached according to its TTL (with **TTL** as the max).
+Note that **TTL** only caps the cache duration and does not extend it. A record with a 30s TTL
+will still be cached for 30s even with `cache 600`. The minimum cache duration defaults to 5
+seconds and can be adjusted per cache type using **MINTTL** in the `success` or `denial` directives.
+
 A cache is divided into 256 shards, each holding up to 39 items by default - for a total size
 of 256 * 39 = 9984 items.
 
@@ -39,7 +43,7 @@ cache [TTL] [ZONES...] {
     success CAPACITY [TTL] [MINTTL]
     denial CAPACITY [TTL] [MINTTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
-    serve_stale [DURATION] [REFRESH_MODE]
+    serve_stale [DURATION] [REFRESH_MODE [VERIFY_TIMEOUT]]
     servfail DURATION
     disable success|denial [ZONES...]
     keepttl
@@ -59,6 +63,9 @@ cache [TTL] [ZONES...] {
   **DURATION** defaults to 1m. Prefetching will happen when the TTL drops below **PERCENTAGE**,
   which defaults to `10%`, or latest 1 second before TTL expiration. Values should be in the range `[10%, 90%]`.
   Note the percent sign is mandatory. **PERCENTAGE** is treated as an `int`.
+  Concurrent requests that trigger a prefetch for the same cache entry dispatch at most one
+  background fetch, so prefetch load scales with the number of distinct eligible entries rather
+  than request rate.
 * `serve_stale`, when serve\_stale is set, cache will always serve an expired entry to a client if there is one
   available as long as it has not been expired for longer than **DURATION** (default 1 hour). By default, the _cache_ plugin will
   attempt to refresh the cache entry after sending the expired cache entry to the client. The
@@ -68,6 +75,12 @@ cache [TTL] [ZONES...] {
   checking to see if the entry is available from the source. **REFRESH_MODE** defaults to `immediate`. Setting this
   value to `verify` can lead to increased latency when serving stale responses, but will prevent stale entries
   from ever being served if an updated response can be retrieved from the source.
+  In `immediate` mode, concurrent requests for the same expired entry dispatch at most one
+  background refresh.
+  **VERIFY_TIMEOUT** is only valid with `verify` and bounds how long the cache waits for the upstream
+  verify before falling back to the stale entry. The verify continues in the background and refreshes the
+  cache when it eventually succeeds, so subsequent queries see the fresh entry. The default of `0` means
+  wait until the upstream's own timeout (the original `verify` behavior). Example: `serve_stale 1h verify 100ms`.
 * `servfail` cache SERVFAIL responses for **DURATION**.  Setting **DURATION** to 0 will disable caching of SERVFAIL
   responses.  If this option is not set, SERVFAIL responses will be cached for 5 seconds.  **DURATION** may not be
   greater than 5 minutes.

--- a/content/plugins/dnssec.md
+++ b/content/plugins/dnssec.md
@@ -4,7 +4,7 @@ description = "*dnssec* enables on-the-fly DNSSEC signing of served data."
 weight = 14
 tags = ["plugin", "dnssec"]
 categories = ["plugin"]
-date = "2024-11-22T08:09:54.87754811"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -68,7 +68,7 @@ used.
   as a new secret in AWS Secrets Manager with the specified name and description. CoreDNS will then fetch
   the key data from AWS Secrets Manager when using the `key aws_secretsmanager` directive.
 
-  [AWS SDK for Go V2](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials) is used
+  [AWS SDK for Go V2](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-auth.html) is used
   for authentication with AWS Secrets Manager. Make sure the provided AWS credentials have the necessary
   permissions (e.g., `secretsmanager:GetSecretValue`) to access the specified secrets in AWS Secrets Manager.
 

--- a/content/plugins/dnstap.md
+++ b/content/plugins/dnstap.md
@@ -4,7 +4,7 @@ description = "*dnstap* enables logging to dnstap."
 weight = 15
 tags = ["plugin", "dnstap"]
 categories = ["plugin"]
-date = "2025-10-13T05:58:44.87744810"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -16,6 +16,8 @@ Every message is sent to the socket as soon as it comes in, the *dnstap* plugin 
 10000 messages, above that number dnstap messages will be dropped (this is logged).
 
 ## Syntax
+
+### Outgoing Connections (Connect to Sink)
 
 ~~~ txt
 dnstap SOCKET [full] [writebuffer] [queue] {
@@ -35,6 +37,28 @@ dnstap SOCKET [full] [writebuffer] [queue] {
 * **EXTRA** to define "extra" field in dnstap payload, [metadata](../metadata/) replacement available here.
 * `skipverify` to skip tls verification during connection. Default to be secure
 
+### Incoming Connections (Accept from Sinks)
+
+~~~ txt
+dnstap listen SOCKET [full] {
+  [identity IDENTITY]
+  [version VERSION]
+  [extra EXTRA]
+  [tls CERT KEY [CA]]
+  [skipverify]
+}
+~~~
+
+* `listen` indicates this is a listening socket that accepts incoming connections from dnstap sinks.
+* **SOCKET** is the socket address to listen on (e.g., `tcp://127.0.0.1:6000`, `unix:///tmp/dnstap.sock`).
+* `full` to include the wire-format DNS message.
+* **IDENTITY** to override the identity of the server. Defaults to the hostname.
+* **VERSION** to override the version field. Defaults to the CoreDNS version.
+* **EXTRA** to define "extra" field in dnstap payload, [metadata](../metadata/) replacement available here.
+* `tls CERT KEY [CA]` to enable TLS for the listener. **CERT** and **KEY** are paths to the server certificate and key files. Optional **CA** is the path to the CA certificate for client verification.
+* `skipverify` to skip client certificate verification. Default is to verify client certificates. Equivalent to the **CA** option above being unspecified.
+
+**Note:** Incoming connections use unbuffered channels to broadcast events. If a connected sink becomes slow or disconnected, messages are dropped for that sink only, and the connection is closed.
 
 ## Examples
 
@@ -95,6 +119,35 @@ dnstap tls://127.0.0.1:6000 full {
 }
 ~~~
 
+Listen for incoming dnstap sink connections on a Unix socket.
+
+~~~ txt
+dnstap listen /tmp/dnstap.sock full
+~~~
+
+Listen for incoming dnstap sink connections on TCP.
+
+~~~ txt
+dnstap listen tcp://127.0.0.1:6000 full
+~~~
+
+Listen for incoming dnstap sink connections on TLS with mTLS client authentication.
+
+~~~ txt
+dnstap listen tls://127.0.0.1:6000 full {
+  tls /path/to/server-cert.pem /path/to/server-key.pem /path/to/ca.pem
+}
+~~~
+
+Listen for incoming dnstap sink connections on TLS without client certificate verification.
+
+~~~ txt
+dnstap listen tls://127.0.0.1:6000 full {
+  tls /path/to/server-cert.pem /path/to/server-key.pem
+  skipverify
+}
+~~~
+
 You can use _dnstap_ more than once to define multiple taps. The following logs information including the
 wire-format DNS message about client requests and responses to */tmp/dnstap.sock*,
 and also sends client requests and responses without wire-format DNS messages to a remote FQDN.
@@ -102,6 +155,13 @@ and also sends client requests and responses without wire-format DNS messages to
 ~~~ txt
 dnstap /tmp/dnstap.sock full
 dnstap tcp://example.com:6000
+~~~
+
+You can also combine outgoing connections with incoming listeners:
+
+~~~ txt
+dnstap tcp://remote-collector.example.com:6000 full
+dnstap listen tcp://127.0.0.1:6001 full
 ~~~
 
 ## Command Line Tool

--- a/content/plugins/etcd.md
+++ b/content/plugins/etcd.md
@@ -4,7 +4,7 @@ description = "*etcd* enables SkyDNS service discovery from etcd."
 weight = 18
 tags = ["plugin", "etcd"]
 categories = ["plugin"]
-date = "2025-09-09T18:54:52.8775289"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -134,7 +134,7 @@ If you prefer, you can use `curl` to populate the `etcd` server, but with `curl`
 endpoint URL depends on the version of `etcd`. For instance, `etcd v3.2` or before uses only
 [CLIENT-URL]/v3alpha/* while `etcd v3.5` or later uses [CLIENT-URL]/v3/* . Also, Key and Value must
 be base64 encoded in the JSON payload. With `etcdctl` these details are automatically taken care
-of. You can check [this document](https://github.com/coreos/etcd/blob/master/Documentation/dev-guide/api_grpc_gateway.md#notes)
+of. You can check [this document](https://github.com/etcd-io/website/blob/main/content/en/docs/v3.2/dev-guide/api_grpc_gateway.md)
 for details.
 
 ### Reverse zones

--- a/content/plugins/file.md
+++ b/content/plugins/file.md
@@ -4,7 +4,7 @@ description = "*file* enables serving zone data from an RFC 1035-style master fi
 weight = 19
 tags = ["plugin", "file"]
 categories = ["plugin"]
-date = "2025-06-13T10:26:16.8771686"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -30,6 +30,7 @@ If you want to round-robin A and AAAA responses look at the *loadbalance* plugin
 ~~~
 file DBFILE [ZONES... ] {
     reload DURATION
+    reload_by_mtime
     fallthrough [ZONES...]
 }
 ~~~
@@ -37,6 +38,8 @@ file DBFILE [ZONES... ] {
 * `reload` interval to perform a reload of the zone if the SOA version changes. Default is one minute.
   Value of `0` means to not scan for changes and reload. For example, `30s` checks the zonefile every 30 seconds
   and reloads the zone when serial changes.
+* `reload_by_mtime` if set, decision to reload the zone will be based on the zone file modification time,
+  instead of change in the SOA serial.
 * `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
   If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin
   is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only

--- a/content/plugins/forward.md
+++ b/content/plugins/forward.md
@@ -4,7 +4,7 @@ description = "*forward* facilitates proxying DNS messages to upstream resolvers
 weight = 20
 tags = ["plugin", "forward"]
 categories = ["plugin"]
-date = "2026-01-17T06:17:00.877081"
+date = "2026-07-01T06:05:45.8774587"
 +++
 
 ## Description
@@ -34,7 +34,9 @@ forward FROM TO...
   that expand to multiple reverse zones are not fully supported; only the first expanded zone is used.
 * **TO...** are the destination endpoints to forward to. The **TO** syntax allows you to specify
   a protocol, `tls://9.9.9.9` or `dns://` (or no protocol) for plain DNS. The number of upstreams is
-  limited to 15.
+  limited to 15. In addition to IP addresses and files (like `/etc/resolv.conf`), **TO** can also be
+  a hostname (e.g., `my-dns.svc.cluster.local`). Hostnames are resolved to IP addresses at startup.
+  See the `resolver` option below.
 
 Multiple upstreams are randomized (see `policy`) on first use. When a healthy proxy returns an error
 during the exchange the next upstream in the list is tried.
@@ -58,6 +60,7 @@ forward FROM TO... {
     next RCODE_1 [RCODE_2] [RCODE_3...]
     failfast_all_unhealthy_upstreams
     failover RCODE_1 [RCODE_2] [RCODE_3...]
+    resolver IP[:PORT] [IP[:PORT]...]
 }
 ~~~
 
@@ -114,8 +117,10 @@ forward FROM TO... {
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
 * `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored
+* `next_on_nodata` If `NOERROR` is returned by the remote, but an empty answer section (`NODATA`) was provided, execute the next `forward` plugin, if configured.
 * `failfast_all_unhealthy_upstreams` - determines the handling of requests when all upstream servers are unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL responses for all requests. By default, requests are sent to a random upstream.
 * `failover` - By default when a DNS lookup fails to return a DNS response (e.g. timeout), _forward_ will attempt a lookup on the next upstream server. The `failover` option will make _forward_ do the same for any response with a response code matching an `RCODE` ( e.g. `SERVFAIL`、`REFUSED`). `NOERROR` cannot be used. If all upstreams have been tried, the response from the last attempt is returned.
+* `resolver` **IP[:PORT] [IP[:PORT]...]** specifies one or more DNS resolver addresses used to resolve hostname-based **TO** endpoints at startup. If not specified, the system resolver (`/etc/resolv.conf`) is used. Each address is either a bare IP (IPv4 or IPv6, port 53 assumed) or `IP:port`. Multiple addresses can be specified for redundancy.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls_servername` for different upstreams you're out of luck.
@@ -312,6 +317,16 @@ In the following example, if the response from `1.2.3.4` is `SERVFAIL` or `REFUS
      policy sequential
      failover SERVFAIL REFUSED
   }
+}
+~~~
+
+Forward to an upstream identified by hostname, using a specific resolver to look it up:
+
+~~~ txt
+. {
+    forward . dns.example.local {
+        resolver 10.0.0.1
+    }
 }
 ~~~
 

--- a/content/plugins/hosts.md
+++ b/content/plugins/hosts.md
@@ -1,10 +1,10 @@
 +++
 title = "hosts"
 description = "*hosts* enables serving zone data from a `/etc/hosts` style file."
-weight = 23
+weight = 26
 tags = ["plugin", "hosts"]
 categories = ["plugin"]
-date = "2020-09-18T09:42:40.8774089"
+date = "2026-07-01T06:05:45.8774587"
 +++
 
 ## Description

--- a/content/plugins/kubernetes.md
+++ b/content/plugins/kubernetes.md
@@ -4,7 +4,7 @@ description = "*kubernetes* enables reading zone data from a Kubernetes cluster.
 weight = 31
 tags = ["plugin", "kubernetes"]
 categories = ["plugin"]
-date = "2026-03-06T16:27:00.877083"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -72,12 +72,12 @@ kubernetes [ZONES...] {
    If this option is omitted all namespaces are exposed
 * `namespace_labels` **EXPRESSION** only expose the records for Kubernetes namespaces that match this label selector.
    The label selector syntax is described in the
-   [Kubernetes User Guide - Labels](https://kubernetes.io/docs/user-guide/labels/). An example that
+   [Kubernetes Documentation - Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). An example that
    only exposes namespaces labeled as "istio-injection=enabled", would use:
    `labels istio-injection=enabled`.
 * `labels` **EXPRESSION** only exposes the records for Kubernetes objects that match this label selector.
    The label selector syntax is described in the
-   [Kubernetes User Guide - Labels](https://kubernetes.io/docs/user-guide/labels/). An example that
+   [Kubernetes Documentation - Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/). An example that
    only exposes objects labeled as "application=nginx" in the "staging" or "qa" environments, would
    use: `labels environment in (staging, qa),application=nginx`.
 * `pods` **POD-MODE** sets the mode for handling IP-based pod A records, e.g.
@@ -270,7 +270,7 @@ The following are client level metrics to monitor apiserver request latency & st
 
 ## Bugs
 
-The duration metric only supports the "headless\_with\_selector" service currently.
+The duration metric does not yet support the `headless_without_selector` service kind.
 
 ## See Also
 

--- a/content/plugins/metrics.md
+++ b/content/plugins/metrics.md
@@ -1,10 +1,10 @@
 +++
 title = "prometheus"
 description = "*prometheus* enables [Prometheus](https://prometheus.io/) metrics."
-weight = 34
+weight = 37
 tags = ["plugin", "prometheus"]
 categories = ["plugin"]
-date = "2025-06-13T10:26:16.8771686"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -58,13 +58,21 @@ This plugin can only be used once per Server Block.
 ## Syntax
 
 ~~~
-prometheus [ADDRESS]
+prometheus [ADDRESS] {
+    runtime_metrics
+}
 ~~~
 
 For each zone that you want to see metrics for.
 
 It optionally takes a bind address to which the metrics are exported; the default
 listens on `localhost:9153`. The metrics path is fixed to `/metrics`.
+
+* `runtime_metrics` exports the full Go [runtime/metrics](https://pkg.go.dev/runtime/metrics)
+  set — notably `go_cpu_classes_*` for CPU attribution (GC mark/assist/pause vs user code)
+  and `go_sched_latencies_seconds` for goroutine scheduling delay. Adds roughly 100 scalars
+  and 8 histograms. This is a process-wide latch: enabling it in any server block enables it
+  for all, and it stays enabled across reloads until restart.
 
 ## Examples
 

--- a/content/plugins/proxyproto.md
+++ b/content/plugins/proxyproto.md
@@ -4,7 +4,7 @@ description = "*proxyproto* add [PROXY protocol](https://www.haproxy.org/downloa
 weight = 43
 tags = ["plugin", "proxyproto"]
 categories = ["plugin"]
-date = "2026-03-06T16:27:00.877083"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -19,6 +19,7 @@ client's IP address and port information.
 proxyproto {
     allow <CIDR...>
     default <use|ignore|reject|skip>
+    udp_session_tracking <duration> [max_sessions]
 }
 ~~~
 
@@ -26,15 +27,26 @@ If `allow` is unspecified, PROXY protocol headers are accepted from all IP addre
 The `default` option controls how connections from sources not listed in `allow` are handled.
 If `default` is unspecified, it defaults to `ignore`.
 The possible values are:
+
 - `use`: accept and use PROXY protocol headers from these sources
 - `ignore`: accept and ignore PROXY protocol headers from other sources
 - `reject`: reject connections with PROXY protocol headers from other sources
 - `skip`: skip PROXY protocol processing for connections from other sources, treating them as normal connections preserving the PROXY protocol headers.
 
+The `udp_session_tracking <duration> [max_sessions]` option enables UDP session state tracking
+for Cloudflare Spectrum's PROXY Protocol v2 over UDP. Spectrum sends the PPv2 header as a
+standalone first datagram (with no DNS payload). Subsequent datagrams from the same client arrive
+without any header. When this option is set to a positive duration, the real client address from
+the header-only datagram is cached (keyed by the Spectrum-side remote address) for that duration
+and automatically applied to all subsequent headerless datagrams within that window. The TTL is
+refreshed on each matching packet. The optional `max_sessions` argument caps the number of
+concurrent sessions in the LRU cache (default: 10240). This option has no effect for TCP
+connections.
 
 ## Examples
 
 In this configuration, we allow PROXY protocol connections from all IP addresses:
+
 ~~~ corefile
 . {
     proxyproto
@@ -44,6 +56,7 @@ In this configuration, we allow PROXY protocol connections from all IP addresses
 
 In this configuration, we only allow PROXY protocol connections from the specified CIDR ranges
 and ignore proxy protocol headers from other sources:
+
 ~~~ corefile
 . {
     proxyproto {
@@ -55,11 +68,38 @@ and ignore proxy protocol headers from other sources:
 
 In this configuration, we only allow PROXY protocol headers from the specified CIDR ranges and reject
 connections without valid PROXY protocol headers from those sources:
+
 ~~~ corefile
 . {
     proxyproto {
         allow 192.168.1.1/32
         default reject
+    }
+    forward . /etc/resolv.conf
+}
+~~~
+
+In this configuration, we enable UDP session tracking for Cloudflare Spectrum's PPv2-over-UDP
+with a 28-second TTL (slightly shorter than Spectrum's 30-second UDP idle timeout) and the
+default session cap of 10240:
+
+~~~ corefile
+. {
+    proxyproto {
+        allow 192.168.1.1/32
+        udp_session_tracking 28s
+    }
+    forward . /etc/resolv.conf
+}
+~~~
+
+In this configuration, the session cap is raised to 20480:
+
+~~~ corefile
+. {
+    proxyproto {
+        allow 192.168.1.1/32
+        udp_session_tracking 28s 20000
     }
     forward . /etc/resolv.conf
 }

--- a/content/plugins/secondary.md
+++ b/content/plugins/secondary.md
@@ -1,10 +1,10 @@
 +++
 title = "secondary"
 description = "*secondary* enables serving a zone retrieved from a primary server."
-weight = 43
+weight = 50
 tags = ["plugin", "secondary"]
 categories = ["plugin"]
-date = "2021-09-21T15:01:04.877489"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -30,12 +30,18 @@ A working syntax would be:
 ~~~
 secondary [zones...] {
     transfer from ADDRESS [ADDRESS...]
+    fallthrough [ZONES...]
 }
 ~~~
 
 *  `transfer from` specifies from which **ADDRESS** to fetch the zone. It can be specified multiple
    times; if one does not work, another will be tried. Transferring this zone outwards again can be
    done by enabling the *transfer* plugin.
+
+*  `fallthrough` If a query for a record in the zone results in NXDOMAIN, the query will be passed
+   to the next plugin in the chain. If **[ZONES...]** are listed, then only queries for those zones
+   will be subject to fallthrough. This can be useful in split DNS setups where the secondary zone
+   contains only partial records.
 
 When a zone is due to be refreshed (refresh timer fires) a random jitter of 5 seconds is applied,
 before fetching. In the case of retry this will be 2 seconds. If there are any errors during the

--- a/content/plugins/tls.md
+++ b/content/plugins/tls.md
@@ -1,10 +1,10 @@
 +++
 title = "tls"
 description = "*tls* allows you to configure the server certificates for the TLS, gRPC, DoH servers."
-weight = 48
+weight = 54
 tags = ["plugin", "tls"]
 categories = ["plugin"]
-date = "2024-11-22T08:09:54.87754811"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -30,6 +30,7 @@ Parameter CA is optional. If not set, system CAs can be used to verify the clien
 ~~~ txt
 tls CERT KEY [CA] {
     client_auth nocert|request|require|verify_if_given|require_and_verify
+    keylog FILE
 }
 ~~~
 
@@ -37,6 +38,9 @@ If client\_auth option is specified, it controls the client authentication polic
 The option value corresponds to the [ClientAuthType values of the Go tls package](https://golang.org/pkg/crypto/tls/#ClientAuthType): NoClientCert, RequestClientCert, RequireAnyClientCert, VerifyClientCertIfGiven, and RequireAndVerifyClientCert, respectively.
 The default is "nocert".  Note that it makes no sense to specify parameter CA unless this option is
 set to verify\_if\_given or require\_and\_verify.
+
+The keylog can be specified to export TLS master secrets in key log format to allow external programs
+to decrypt TLS connections. It compromises security and should only be used for debugging!
 
 ## Examples
 

--- a/content/plugins/trace.md
+++ b/content/plugins/trace.md
@@ -1,10 +1,10 @@
 +++
 title = "trace"
 description = "*trace* enables OpenTracing-based tracing of DNS requests as they go through the plugin chain."
-weight = 47
+weight = 55
 tags = ["plugin", "trace"]
 categories = ["plugin"]
-date = "2022-09-08T18:42:54.8775489"
+date = "2026-07-01T06:05:45.8774587"
 +++
 
 ## Description

--- a/content/plugins/transfer.md
+++ b/content/plugins/transfer.md
@@ -1,10 +1,10 @@
 +++
 title = "transfer"
 description = "*transfer* perform (outgoing) zone transfers for other plugins."
-weight = 48
+weight = 56
 tags = ["plugin", "transfer"]
 categories = ["plugin"]
-date = "2022-01-24T14:51:48.8774881"
+date = "2026-07-01T06:05:45.8774587"
 +++
 
 ## Description

--- a/content/plugins/tsig.md
+++ b/content/plugins/tsig.md
@@ -1,10 +1,10 @@
 +++
 title = "tsig"
 description = "*tsig* define TSIG keys, validate incoming TSIG signed requests and sign responses."
-weight = 49
+weight = 57
 tags = ["plugin", "tsig"]
 categories = ["plugin"]
-date = "2022-09-08T18:42:54.8775489"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -22,6 +22,7 @@ tsig [ZONE...] {
   secret NAME KEY
   secrets FILE
   require [QTYPE...]
+  require_opcode [OPCODE...]
 }
 ~~~
 
@@ -39,9 +40,14 @@ tsig [ZONE...] {
      ```
      Each key may also specify an `algorithm` e.g. `algorithm hmac-sha256;`, but this is currently ignored by the plugin.
 
-     * `require` **QTYPE...** - the query types that must be TSIG'd. Requests of the specified types
-   will be `REFUSED` if they are not signed.`require all` will require requests of all types to be
+   * `require` **QTYPE...** - the query types that must be TSIG'd. Requests of the specified types
+   will be `REFUSED` if they are not signed. `require all` will require requests of all types to be
    signed. `require none` will not require requests any types to be signed. Default behavior is to not require.
+
+   * `require_opcode` **OPCODE...** - the opcodes that must be TSIG'd. Requests with the specified opcodes
+   will be `REFUSED` if they are not signed. Valid opcodes are: `QUERY`, `IQUERY`, `STATUS`, `NOTIFY`, `UPDATE`.
+   `require_opcode all` will require requests with all opcodes to be signed. `require_opcode none` will not
+   require requests with any opcode to be signed. Default behavior is to not require.
 
 ## Examples
 
@@ -68,6 +74,17 @@ auth.zone {
     require all
   }
   forward . 10.1.0.2
+}
+```
+
+Require TSIG signed transactions for UPDATE and NOTIFY operations to `dynamic.zone`.
+
+```
+dynamic.zone {
+  tsig {
+    secret dynamic.zone.key. NoTCJU+DMqFWywaPyxSijrDEA/eC3nK0xi3AMEZuPVk=
+    require_opcode UPDATE NOTIFY
+  }
 }
 ```
 

--- a/content/plugins/view.md
+++ b/content/plugins/view.md
@@ -1,10 +1,10 @@
 +++
 title = "view"
 description = "*view* defines conditions that must be met for a DNS request to be routed to the server block."
-weight = 54
+weight = 58
 tags = ["plugin", "view"]
 categories = ["plugin"]
-date = "2025-10-13T05:58:44.87744810"
+date = "2026-07-01T06:01:46.8774687"
 +++
 
 ## Description
@@ -27,6 +27,15 @@ view NAME {
   incoming queries to the enclosing server block.
 
 For expression syntax and examples, see the Expressions and Examples sections.
+
+## Server Block Ordering
+
+Server blocks sharing the same zone and port are evaluated **top to bottom**. The first block whose
+view expression matches (or that has no view) handles the query. An unfiltered catch-all block
+declared *before* a filtered block will shadow it, because the catch-all matches every query.
+
+To get the expected split-DNS behavior, declare all filtered (view) blocks first and the unfiltered
+catch-all block last.
 
 ## Examples
 

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.14.2"
+  version = "1.14.4"


### PR DESCRIPTION
Built based on CoreDNS [v1.14.4](https://github.com/coredns/coredns/releases/tag/v1.14.4) tag.

cc: @yongtang 