### PR TITLE
Update k8s_gateway to maintained repository

### DIFF
--- a/content/explugins/k8s_gateway.md
+++ b/content/explugins/k8s_gateway.md
@@ -5,8 +5,8 @@ weight = 10
 tags = [  "plugin" , "k8s" ]
 categories = [ "plugin", "external", "kubernetes" ]
 date = "2020-09-19T12:00:00-08:00"
-repo = "https://github.com/ori-edge/k8s_gateway"
-home = "https://github.com/ori-edge/k8s_gateway/blob/master/README.md"
+repo = "https://github.com/k8s-gateway/k8s_gateway"
+home = "https://github.com/k8s-gateway/k8s_gateway/blob/master/README.md"
 +++
 
 ## Description

--- a/content/explugins/k8s_gateway.md
+++ b/content/explugins/k8s_gateway.md
@@ -11,7 +11,7 @@ home = "https://github.com/ori-edge/k8s_gateway/blob/master/README.md"
 
 ## Description
 
-This plugin is very similar to [k8s_external](https://coredns.io/plugins/k8s_external/) but supporting all types of Kubernetes external resources - Ingress, Service of type LoadBalancer and `networking.x-k8s.io/Gateway` (when it becomes available). 
+This plugin is very similar to [k8s_external](https://coredns.io/plugins/k8s_external/) but supporting all types of Kubernetes external resources - Ingress, Service of type LoadBalancer, HTTPRoutes, TLSRoutes, GRPCRoutes from the Gateway API project.
 
 This plugin relies on it's own connection to the k8s API server and doesn't share any code with the existing [kubernetes](https://coredns.io/plugins/kubernetes/) plugin. The assumption is that this plugin can now be deployed as a separate instance (alongside the internal kube-dns) and act as a single external DNS interface into your Kubernetes cluster(s).
 


### PR DESCRIPTION
The original ori-edge repository of k8s_gateway is no longer maintained as per the readme, and redirects users to k8s-gateway/k8s_gateway. Updated the link to the repository, and updated latest resource types supported.