### PR TITLE
chore: bump to v1.14.6

### DIFF
--- a/content/blog/coredns-1.14.5.md
+++ b/content/blog/coredns-1.14.5.md
@@ -1,0 +1,72 @@
++++
+title = "CoreDNS-1.14.5 Release"
+description = "CoreDNS-1.14.5 Release Notes."
+tags = ["Release", "1.14.5", "Notes"]
+release = "1.14.5"
+date = "2026-07-10T00:00:00+00:00"
+author = "coredns"
++++
+
+This release improves DNS transport security and operational reliability, with
+safer DoH/DoH3 handling, enhanced forwarding configuration, and improved dnstap
+support. It also adds robustness improvements across file serving, secondary
+zones, transfers, rewrites, hosts handling, and error processing, while fixing
+several edge cases in DNS response handling.
+
+## Brought to You By
+
+Aaron Mark
+Amirhossein Ebrahimzade
+Antoine
+Baltasar Blanco
+Cedric Wang
+Ilya Kulakov
+Immanuel Tikhonov
+Jaime Hablutzel
+Jonathan Tooker
+Omkhar Arasaratnam
+Pavel Lazureykis
+SEONGHYUN HONG
+Saleh
+Thomas Gosteli
+Ville Vesilehto
+Yong Tang
+houyuwushang
+rpb-ant
+
+## Noteworthy Changes
+
+core: Accept scoped IPv6 addresses in transfer targets (https://github.com/coredns/coredns/pull/8204)
+core: Bound DoQ stream read with the server read timeout (https://github.com/coredns/coredns/pull/8231)
+core: Classify nxdomain without soa as denial (https://github.com/coredns/coredns/pull/8199)
+core: Guard Join against an empty label slice (https://github.com/coredns/coredns/pull/8225)
+core: Propagate HTTPRequestValidateFunc to all configs in a server block (https://github.com/coredns/coredns/pull/8169)
+core: Sanitize DoH/DoH3 request parse errors (https://github.com/coredns/coredns/pull/8254)
+core: Use Go TLS defaults (https://github.com/coredns/coredns/pull/8227)
+core: Add Config.UDPDecorateWriterFunc for external plugins (https://github.com/coredns/coredns/pull/8257)
+plugin/auto: Warn on duplicate zone file origins (https://github.com/coredns/coredns/pull/8191)
+plugin/cache: Add regression test for AD bit not partitioning the cache (https://github.com/coredns/coredns/pull/8214)
+plugin/dnstap: Close the previous connection before reconnecting (https://github.com/coredns/coredns/pull/8224)
+plugin/dnstap: Fix self-deadlock in listener broadcast on client flush error (https://github.com/coredns/coredns/pull/8260)
+plugin/dnstap: Store IPv4-mapped IPv6 addresses as 4 octets with SocketFamily INET (https://github.com/coredns/coredns/pull/8186)
+plugin/erratic: Apply default truncate amount of 2 for bare `truncate` (https://github.com/coredns/coredns/pull/8240)
+plugin/file: Return SOA in authority for negative CNAME target answers (https://github.com/coredns/coredns/pull/8226)
+plugin/file: Run additional processing for wildcard answers (https://github.com/coredns/coredns/pull/8222)
+plugin/forward: Add doh support (https://github.com/coredns/coredns/pull/8004)
+plugin/forward: Make dnstap FORWARDER_* describe the socket from CoreDNS to upstream (https://github.com/coredns/coredns/pull/8184)
+plugin/forward: Make per-upstream read timeout configurable (https://github.com/coredns/coredns/pull/8205)
+plugin/forward: Restore old behavior forward plugin continue on empty conf file (https://github.com/coredns/coredns/pull/8203)
+plugin/hosts: Add wildcard support (https://github.com/coredns/coredns/pull/8185)
+plugin/hosts: Fall through unsupported query types (https://github.com/coredns/coredns/pull/8193)
+plugin/hosts: Fix data race between lookups and reload (https://github.com/coredns/coredns/pull/8253)
+plugin/kubernetes: Fix AXFR panic when nsAddrs returns multiple records (https://github.com/coredns/coredns/pull/8256)
+plugin/local: Handle names under .localhost. (https://github.com/coredns/coredns/pull/8151)
+plugin/log: Synthesize deferred error responses (https://github.com/coredns/coredns/pull/8200)
+plugin/rewrite: Fix nil-pointer panic in EDNS0 response reversion with no OPT record (https://github.com/coredns/coredns/pull/8190)
+plugin/rewrite: Restore the original question on empty replies (https://github.com/coredns/coredns/pull/8212)
+plugin/secondary: Parse catalog zones after transfer (https://github.com/coredns/coredns/pull/8209)
+plugin/secondary: Stop update loop on reload shutdown (https://github.com/coredns/coredns/pull/8198)
+plugin/trace: Correct Zipkin v2 endpoint docs (https://github.com/coredns/coredns/pull/8202)
+plugin/transfer: Configure notify source address (https://github.com/coredns/coredns/pull/8192)
+plugin/transfer: Fix panic in CoreDNS transfer plugin caused by empty DNS record (https://github.com/coredns/coredns/pull/8207)
+plugin/tsig: Don't echo client's TSIG.Error if verification is successful (https://github.com/coredns/coredns/pull/8215)

--- a/content/blog/coredns-1.14.6.md
+++ b/content/blog/coredns-1.14.6.md
@@ -1,0 +1,27 @@
++++
+title = "CoreDNS-1.14.6 Release"
+description = "CoreDNS-1.14.6 Release Notes."
+tags = ["Release", "1.14.6", "Notes"]
+release = "1.14.6"
+date = "2026-07-10T00:00:00+00:00"
+author = "coredns"
++++
+
+This patch release focuses on fixing ARM and MIPS build issues introduced in
+v1.14.5 by downgrading the dd-trace-go dependency, while also including
+improvements to forwarding and secondary zone support.
+
+## Brought to You By
+
+Filippo125
+houyuwushang
+Immanuel Tikhonov
+Ville Vesilehto
+Yong Tang
+
+## Noteworthy Changes
+
+core: Downgrade dd-trace-go to v2.8.2 (https://github.com/coredns/coredns/pull/8266)
+plugin/auto: Keep first matching zone file for duplicate origins (https://github.com/coredns/coredns/pull/8216)
+plugin/forward: Add source_address directive (https://github.com/coredns/coredns/pull/8011)
+plugin/secondary: Serve catalog member zones (https://github.com/coredns/coredns/pull/8230)

--- a/content/plugins/auto.md
+++ b/content/plugins/auto.md
@@ -4,7 +4,7 @@ description = "*auto* enables serving zone data from an RFC 1035-style master fi
 weight = 3
 tags = ["plugin", "auto"]
 categories = ["plugin"]
-date = "2025-12-11T04:36:33.87733812"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
@@ -31,7 +31,8 @@ are used.
   like `{<number>}` are replaced with the respective matches in the file name, e.g. `{1}` is the
   first match, `{2}` is the second. The default is: `db\.(.*)  {1}` i.e. from a file with the
   name `db.example.com`, the extracted origin will be `example.com`. **REGEXP** must not be longer
-  than 10000 characters.
+  than 10000 characters. **REGEXP** is unanchored; use `^` and `$` to require matching the full
+  file name, for example `^(.*)\.zone$` to avoid matching backup files like `example.org.zone.bak`.
 * `reload` interval to perform reloads of zones if SOA version changes and zonefiles. It specifies how often CoreDNS should scan the directory to watch for file removal and addition. Default is one minute.
   Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
   and reloads zone when serial changes.

--- a/content/plugins/etcd.md
+++ b/content/plugins/etcd.md
@@ -4,7 +4,7 @@ description = "*etcd* enables SkyDNS service discovery from etcd."
 weight = 18
 tags = ["plugin", "etcd"]
 categories = ["plugin"]
-date = "2026-07-01T06:01:46.8774687"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
@@ -58,6 +58,10 @@ etcd [ZONES...] {
     * three arguments - path to cert PEM file, path to client private key PEM file, path to CA PEM
       file - if the server certificate is not signed by a system-installed CA and client certificate
       is needed.
+
+CoreDNS sets the minimum TLS version to TLS 1.2. The maximum TLS version, TLS 1.2 cipher suites, and
+key exchange mechanisms use the Go `crypto/tls` defaults.
+
 * `min-lease-ttl` the minimum TTL for DNS records based on etcd lease duration. Accepts flexible time formats like '30', '30s', '5m', '1h', '2h30m'. Default: 30 seconds.
 * `max-lease-ttl` the maximum TTL for DNS records based on etcd lease duration. Accepts flexible time formats like '30', '30s', '5m', '1h', '2h30m'. Default: 24 hours.
 

--- a/content/plugins/forward.md
+++ b/content/plugins/forward.md
@@ -4,13 +4,13 @@ description = "*forward* facilitates proxying DNS messages to upstream resolvers
 weight = 20
 tags = ["plugin", "forward"]
 categories = ["plugin"]
-date = "2026-07-01T06:05:45.8774587"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
 
-The *forward* plugin re-uses already opened sockets to the upstreams. It supports UDP, TCP and
-DNS-over-TLS and uses in band health checking.
+The *forward* plugin re-uses already opened sockets to the upstreams. It supports UDP, TCP, 
+DNS-over-TLS, DNS-over-HTTPS and uses in band health checking.
 
 When it detects an error a health check is performed. This checks runs in a loop, performing each
 check at a *0.5s* interval for as long as the upstream reports unhealthy. Once healthy we stop
@@ -33,8 +33,8 @@ forward FROM TO...
 * **FROM** is the base domain to match for the request to be forwarded. Domains using CIDR notation
   that expand to multiple reverse zones are not fully supported; only the first expanded zone is used.
 * **TO...** are the destination endpoints to forward to. The **TO** syntax allows you to specify
-  a protocol, `tls://9.9.9.9` or `dns://` (or no protocol) for plain DNS. The number of upstreams is
-  limited to 15. In addition to IP addresses and files (like `/etc/resolv.conf`), **TO** can also be
+  a protocol, `tls://9.9.9.9`, `https://9.9.9.9` (DoH defaults to `/dns-query` path) or `dns://` (or no protocol)
+  for plain DNS. The number of upstreams is limited to 15. In addition to IP addresses and files (like `/etc/resolv.conf`), **TO** can also be
   a hostname (e.g., `my-dns.svc.cluster.local`). Hostnames are resolved to IP addresses at startup.
   See the `resolver` option below.
 
@@ -50,8 +50,10 @@ forward FROM TO... {
     prefer_udp
     expire DURATION
     max_idle_conns INTEGER
+    read_timeout DURATION
     max_fails INTEGER
     max_connect_attempts INTEGER
+    doh_method GET|POST
     tls CERT KEY CA
     tls_servername NAME
     policy random|round_robin|sequential
@@ -60,6 +62,7 @@ forward FROM TO... {
     next RCODE_1 [RCODE_2] [RCODE_3...]
     failfast_all_unhealthy_upstreams
     failover RCODE_1 [RCODE_2] [RCODE_3...]
+    source_address IP
     resolver IP[:PORT] [IP[:PORT]...]
 }
 ~~~
@@ -78,8 +81,14 @@ forward FROM TO... {
   performed for a single incoming DNS request. Default value of 0 means no per-request
   cap.
 * `expire` **DURATION**, expire (cached) connections after this time, the default is 10s.
+* `doh_method` **GET|POST**, whether to use GET or POST http method for DoH requests (defaults to POST).
 * `max_idle_conns` **INTEGER**, maximum number of idle connections to cache per upstream for reuse.
   Default is 0, which means unlimited.
+* `read_timeout` **DURATION**, the per-query read timeout applied to each upstream when waiting for a
+  response. The default is 2s. Increase this if upstreams legitimately take longer than 2s to answer
+  (for example slow recursive resolutions that would otherwise surface as `SERVFAIL`/timeouts). Note
+  that this timeout applies to each upstream individually, so large values reduce the time available
+  to retry other upstreams within a single query.
 * `tls` **CERT** **KEY** **CA** define the TLS properties for TLS connection. From 0 to 3 arguments can be
   provided with the meaning as described below
 
@@ -89,6 +98,9 @@ forward FROM TO... {
     The server certificate is verified with the system CAs
   * `tls` **CERT** **KEY**  **CA** - client authentication is used with the specified cert/key pair.
     The server certificate is verified using the specified CA file
+
+CoreDNS sets the minimum TLS version to TLS 1.2. The maximum TLS version, TLS 1.2 cipher suites, and
+key exchange mechanisms use the Go `crypto/tls` defaults.
 
 * `tls_servername` **NAME** allows you to set a server name in the TLS configuration; for instance 9.9.9.9
   needs this to be set to `dns.quad9.net`. Using TLS forwarding but not setting `tls_servername` results in anyone
@@ -120,6 +132,7 @@ forward FROM TO... {
 * `next_on_nodata` If `NOERROR` is returned by the remote, but an empty answer section (`NODATA`) was provided, execute the next `forward` plugin, if configured.
 * `failfast_all_unhealthy_upstreams` - determines the handling of requests when all upstream servers are unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL responses for all requests. By default, requests are sent to a random upstream.
 * `failover` - By default when a DNS lookup fails to return a DNS response (e.g. timeout), _forward_ will attempt a lookup on the next upstream server. The `failover` option will make _forward_ do the same for any response with a response code matching an `RCODE` ( e.g. `SERVFAIL`、`REFUSED`). `NOERROR` cannot be used. If all upstreams have been tried, the response from the last attempt is returned.
+* `source_address` **IP** - set the address to use for all outgoing requests as source address (also health check query). This works reliably when upstream servers are reachable from that address. However, if upstream servers belong to different networks, care must be taken. The selected source address may not be valid for all upstreams, and responses may fail if return routing is not properly configured. In such cases, make sure that upstream servers have a route back to the configured source address.
 * `resolver` **IP[:PORT] [IP[:PORT]...]** specifies one or more DNS resolver addresses used to resolve hostname-based **TO** endpoints at startup. If not specified, the system resolver (`/etc/resolv.conf`) is used. Each address is either a bare IP (IPv4 or IPv6, port 53 assumed) or `IP:port`. Multiple addresses can be specified for redundancy.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
@@ -151,7 +164,7 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 * `coredns_proxy_conn_cache_misses_total{proxy_name="forward", to, proto}` - count of connection cache misses per upstream and protocol.
 
 Where `to` is one of the upstream servers (**TO** from the config), `rcode` is the returned RCODE
-from the upstream, `proto` is the transport protocol like `udp`, `tcp`, `tcp-tls`.
+from the upstream, `proto` is the transport protocol like `udp`, `tcp`, `tcp-tls`, `https`.
 
 The following metrics have recently been deprecated:
 * `coredns_forward_healthcheck_failures_total{to, rcode}`
@@ -250,6 +263,19 @@ service with health checks.
 }
 ~~~
 
+The same configuration but using DNS-over-HTTPS (DoH) protocol. Note that the implementation uses the default `/dns-query`
+path (custom paths are not supported).
+
+~~~ corefile
+. {
+    forward . https://9.9.9.9 {
+       tls_servername dns.quad9.net
+       health_check 5s
+    }
+    cache 30
+}
+~~~
+
 Or configure other domain name for health check requests
 
 ~~~ corefile
@@ -333,3 +359,5 @@ Forward to an upstream identified by hostname, using a specific resolver to look
 ## See Also
 
 [RFC 7858](https://tools.ietf.org/html/rfc7858) for DNS over TLS.
+
+[RFC 8484](https://tools.ietf.org/html/rfc8484) for DNS over HTTPS.

--- a/content/plugins/grpc.md
+++ b/content/plugins/grpc.md
@@ -4,7 +4,7 @@ description = "*grpc* facilitates proxying DNS messages to upstream resolvers vi
 weight = 22
 tags = ["plugin", "grpc"]
 categories = ["plugin"]
-date = "2025-08-08T17:41:04.877488"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
@@ -52,6 +52,9 @@ grpc FROM TO... {
     The server certificate is verified with the system CAs
   * `tls` **CERT** **KEY**  **CA** - client authentication is used with the specified cert/key pair.
     The server certificate is verified using the specified CA file
+
+CoreDNS sets the minimum TLS version to TLS 1.2. The maximum TLS version, TLS 1.2 cipher suites, and
+key exchange mechanisms use the Go `crypto/tls` defaults.
 
 * `tls_servername` **NAME** allows you to set a server name in the TLS configuration; for instance 9.9.9.9
   needs this to be set to `dns.quad9.net`. Multiple upstreams are still allowed in this scenario,

--- a/content/plugins/hosts.md
+++ b/content/plugins/hosts.md
@@ -4,7 +4,7 @@ description = "*hosts* enables serving zone data from a `/etc/hosts` style file.
 weight = 26
 tags = ["plugin", "hosts"]
 categories = ["plugin"]
-date = "2026-07-01T06:05:45.8774587"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
@@ -39,6 +39,28 @@ Examples:
 ::1                     localhost ip6-localhost ip6-loopback
 fdfc:a744:27b5:3b0e::1  example.com example
 ~~~
+
+### Wildcard records
+
+Owner names may use a `*` as the leftmost label to match one additional label below
+that name. This follows the same wildcard semantics as the *file* plugin.
+
+Examples:
+
+~~~
+192.168.1.10    *.example.com
+192.168.1.11    a.example.com
+192.168.1.12    b.example.com
+~~~
+
+With the entries above:
+
+* `a.example.com` and `b.example.com` resolve to their explicit addresses.
+* `apps.example.com` resolves to `192.168.1.10`.
+* `example.com` does not match the wildcard (the zone apex is excluded).
+* `deep.apps.example.com` does not match `*.example.com` (only one label is matched).
+
+Wildcard entries do not generate PTR records.
 
 ### PTR records
 
@@ -120,6 +142,20 @@ example.hosts example.org {
         fallthrough
     }
     whoami
+}
+~~~
+
+Resolve all single-label subdomains of `example.com` to one address, with explicit
+exceptions, and fall through for everything else under `example.com`.
+
+~~~
+. {
+    hosts example.hosts example.com {
+        192.168.1.10 *.example.com
+        192.168.1.11 www.example.com
+        fallthrough example.com
+    }
+    forward . 8.8.8.8
 }
 ~~~
 

--- a/content/plugins/local.md
+++ b/content/plugins/local.md
@@ -1,24 +1,26 @@
 +++
 title = "local"
 description = "*local* respond to local names."
-weight = 28
+weight = 33
 tags = ["plugin", "local"]
 categories = ["plugin"]
-date = "2020-11-05T14:17:09.8779811"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
 
-*local* will respond with a basic reply to a "local request". Local request are defined to be
-names in the following zones: localhost, 0.in-addr.arpa, 127.in-addr.arpa and 255.in-addr.arpa *and*
-any query asking for `localhost.<domain>`. When seeing the latter a metric counter is increased and
-if *debug* is enabled a debug log is emitted.
+*local* will respond with a basic reply to a "local request". Local requests are defined to be
+names in the following zones: localhost, 0.in-addr.arpa, 127.in-addr.arpa and 255.in-addr.arpa,
+any query under `.localhost.`, and, by default for backward compatibility, any query prefixed by
+`localhost.`. When seeing one of the non-apex localhost forms a metric counter is increased and if
+*debug* is enabled a debug log is emitted.
 
-With *local* enabled any query falling under these zones will get a reply. The prevents the query
+With *local* enabled any query falling under these zones will get a reply. This prevents the query
 from "escaping" to the internet and putting strain on external infrastructure.
 
-The zones are mostly empty, only `localhost.` address records (A and AAAA) are defined and a
-`1.0.0.127.in-addr.arpa.` reverse (PTR) record.
+The zones are mostly empty, only `localhost.`, names under `.localhost.`, and legacy
+`localhost.<domain>` names return loopback address records (A and AAAA), and only
+`1.0.0.127.in-addr.arpa.` has a reverse (PTR) record.
 
 ## Syntax
 
@@ -26,12 +28,25 @@ The zones are mostly empty, only `localhost.` address records (A and AAAA) are d
 local
 ~~~
 
+~~~ txt
+local {
+    localhost_prefix on|off
+}
+~~~
+
+`localhost_prefix` controls the legacy `localhost.<domain>` behavior. The default is `on` for
+backward compatibility. Set it to `off` to only treat names under `.localhost.` as special, which
+matches RFC 6761. The legacy prefix behavior is deprecated and may be disabled by default in a
+future release.
+
 ## Metrics
 
 If monitoring is enabled (via the *prometheus* plugin) then the following metric is exported:
 
-* `coredns_local_localhost_requests_total{}` - a counter of the number of `localhost.<domain>`
-  requests CoreDNS has seen. Note this does *not* count `localhost.` queries.
+* `coredns_local_localhost_requests_total{}` - a counter of the number of non-apex localhost
+  special-case queries CoreDNS has seen. This includes `.localhost.` names and, when
+  `localhost_prefix` is `on`, legacy `localhost.<domain>` names. It does *not* count `localhost.`
+  queries.
 
 Note that this metric *does not* have a `server` label, because it's more interesting to find the
 client(s) performing these queries than to see which server handled it. You'll need to inspect the

--- a/content/plugins/secondary.md
+++ b/content/plugins/secondary.md
@@ -4,7 +4,7 @@ description = "*secondary* enables serving a zone retrieved from a primary serve
 weight = 50
 tags = ["plugin", "secondary"]
 categories = ["plugin"]
-date = "2026-07-01T06:01:46.8774687"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
@@ -30,6 +30,7 @@ A working syntax would be:
 ~~~
 secondary [zones...] {
     transfer from ADDRESS [ADDRESS...]
+    catalog
     fallthrough [ZONES...]
 }
 ~~~
@@ -37,6 +38,10 @@ secondary [zones...] {
 *  `transfer from` specifies from which **ADDRESS** to fetch the zone. It can be specified multiple
    times; if one does not work, another will be tried. Transferring this zone outwards again can be
    done by enabling the *transfer* plugin.
+
+*  `catalog` treats the transferred zone as an RFC 9432 catalog zone. After each successful catalog
+   transfer, CoreDNS adds and removes the catalog member zones and transfers those member zones from
+   the same primary servers.
 
 *  `fallthrough` If a query for a record in the zone results in NXDOMAIN, the query will be passed
    to the next plugin in the chain. If **[ZONES...]** are listed, then only queries for those zones

--- a/content/plugins/timeouts.md
+++ b/content/plugins/timeouts.md
@@ -1,10 +1,10 @@
 +++
 title = "timeouts"
-description = "*timeouts* allows you to configure the server read, write and idle timeouts for the TCP, TLS, DoH and DoQ (idle only) servers."
-weight = 48
+description = "*timeouts* allows you to configure the supported server read, write and idle timeouts for the TCP, TLS, DoH and DoQ servers."
+weight = 53
 tags = ["plugin", "timeouts"]
 categories = ["plugin"]
-date = "2025-06-13T10:26:16.8771686"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
@@ -33,6 +33,11 @@ timeouts {
 For any timeouts that are not provided, default values are used which may vary
 depending on the server type. At least one timeout must be specified otherwise
 the entire timeouts block should be omitted.
+
+The configured timeouts apply where the selected server transport supports
+them. TCP, TLS and DoH servers use the read, write and idle timeouts. DoQ
+servers use the read timeout to bound receiving a query on an opened QUIC
+stream, and the idle timeout to bound idle QUIC connections.
 
 ## Examples
 
@@ -66,12 +71,14 @@ https://. {
 }
 ~~~
 
-Start a DNS-over-QUIC server that has the idle timeout set to two minutes.
+Start a DNS-over-QUIC server that has a 10 second read timeout for receiving a
+query on an opened stream and the idle timeout set to two minutes.
 
 ~~~
 quic://.:853 {
 	tls cert.pem key.pem ca.pem
 	timeouts {
+		read 10s
 		idle 2m
 	}
 	forward . /etc/resolv.conf

--- a/content/plugins/tls.md
+++ b/content/plugins/tls.md
@@ -4,7 +4,7 @@ description = "*tls* allows you to configure the server certificates for the TLS
 weight = 54
 tags = ["plugin", "tls"]
 categories = ["plugin"]
-date = "2026-07-01T06:01:46.8774687"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
@@ -41,6 +41,9 @@ set to verify\_if\_given or require\_and\_verify.
 
 The keylog can be specified to export TLS master secrets in key log format to allow external programs
 to decrypt TLS connections. It compromises security and should only be used for debugging!
+
+CoreDNS sets the minimum TLS version to TLS 1.2. The maximum TLS version, TLS 1.2 cipher suites, and
+key exchange mechanisms use the Go `crypto/tls` defaults.
 
 ## Examples
 

--- a/content/plugins/trace.md
+++ b/content/plugins/trace.md
@@ -4,7 +4,7 @@ description = "*trace* enables OpenTracing-based tracing of DNS requests as they
 weight = 55
 tags = ["plugin", "trace"]
 categories = ["plugin"]
-date = "2026-07-01T06:05:45.8774587"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
@@ -23,7 +23,7 @@ trace [ENDPOINT-TYPE] [ENDPOINT]
 * **ENDPOINT-TYPE** is the type of tracing destination. Currently only `zipkin` and `datadog` are supported.
   Defaults to `zipkin`.
 * **ENDPOINT** is the tracing destination, and defaults to `localhost:9411`. For Zipkin, if
-  **ENDPOINT** does not begin with `http`, then it will be transformed to `http://ENDPOINT/api/v1/spans`.
+  **ENDPOINT** does not begin with `http`, then it will be transformed to `http://ENDPOINT/api/v2/spans`.
 
 With this form, all queries will be traced.
 
@@ -85,7 +85,7 @@ If for some reason you are using an API reverse proxy or something and need to r
 the standard Zipkin URL you can do something like:
 
 ~~~
-trace http://tracinghost:9411/zipkin/api/v1/spans
+trace http://tracinghost:9411/zipkin/api/v2/spans
 ~~~
 
 Using DataDog:

--- a/content/plugins/transfer.md
+++ b/content/plugins/transfer.md
@@ -4,7 +4,7 @@ description = "*transfer* perform (outgoing) zone transfers for other plugins."
 weight = 56
 tags = ["plugin", "transfer"]
 categories = ["plugin"]
-date = "2026-07-01T06:05:45.8774587"
+date = "2026-07-13T15:51:55.8775587"
 +++
 
 ## Description
@@ -25,6 +25,7 @@ use this plugin.
 ~~~
 transfer [ZONE...] {
   to ADDRESS...
+  source ADDRESS
 }
 ~~~
 
@@ -37,6 +38,10 @@ transfer [ZONE...] {
     addresses. Zone change notifications are sent to all **ADDRESS** that are an IP address or
     an IP address and port e.g. `1.2.3.4`, `12:34::56`, `1.2.3.4:5300`, `[12:34::56]:5300`.
     `to` may be specified multiple times.
+
+ *  `source` **ADDRESS** is the local IP address to use when sending zone change
+    notifications to the configured `to` addresses. It does not change which
+    clients are allowed to request AXFR or IXFR transfers.
 
 You can use the _acl_ plugin to further restrict hosts permitted to receive a zone transfer.
 See example below.
@@ -55,6 +60,17 @@ Use in conjunction with the _acl_ plugin to restrict access to subnet 10.1.0.0/1
   }
   transfer {
     to *
+  }
+...
+```
+
+Send NOTIFY messages from a specific local address.
+
+```
+...
+  transfer {
+    to 2001:db8::1
+    source 2001:db8::53
   }
 ...
 ```

--- a/data/coredns.toml
+++ b/data/coredns.toml
@@ -1,2 +1,2 @@
 [release]
-  version = "1.14.4"
+  version = "1.14.6"


### PR DESCRIPTION
Sync docs to latest CoreDNS version 1.14.6.