### PR TITLE
Add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@coredns.io
+Expires: 2027-07-14T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://coredns.io/.well-known/security.txt
+Policy: https://github.com/coredns/coredns/blob/master/.github/SECURITY.md


### PR DESCRIPTION
## What
Add `/.well-known/security.txt` under `static/` so the canonical site serves one.

## Why
`https://coredns.io/.well-known/security.txt` returns 404. [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) makes `/.well-known/security.txt` the standard, machine-discoverable pointer to a project's security reporting channel. This project already runs a security program with a private disclosure address; this just makes it discoverable by the convention. Served verbatim from `static/`, future `Expires` per §2.5.5. Signed off per DCO.

I used AI assistance to identify this and draft the file; I verified the live 404 and the reporting channel myself.